### PR TITLE
Add API logging for WooCheck shipments

### DIFF
--- a/includes/class-wc-check-recibelo.php
+++ b/includes/class-wc-check-recibelo.php
@@ -37,10 +37,15 @@ class WC_Check_Recibelo {
             ]
         );
 
+        error_log( 'Recibelo Request: ' . wp_json_encode( $data ) );
+
         if ( is_wp_error( $response ) ) {
+            error_log( 'Recibelo Response: ' . $response->get_error_message() );
             error_log( 'Recíbelo error: ' . $response->get_error_message() );
             return;
         }
+
+        error_log( 'Recibelo Response: ' . wp_remote_retrieve_body( $response ) );
 
         $body = json_decode( wp_remote_retrieve_body( $response ), true );
 

--- a/includes/class-wc-check-shipit.php
+++ b/includes/class-wc-check-shipit.php
@@ -54,10 +54,15 @@ class WC_Check_Shipit {
             ]
         );
 
+        error_log( 'Shipit Request: ' . wp_json_encode( $data ) );
+
         if ( is_wp_error( $response ) ) {
+            error_log( 'Shipit Response: ' . $response->get_error_message() );
             error_log( 'Shipit error: ' . $response->get_error_message() );
             return;
         }
+
+        error_log( 'Shipit Response: ' . wp_remote_retrieve_body( $response ) );
 
         $body = json_decode( wp_remote_retrieve_body( $response ), true );
 

--- a/wp-config.php
+++ b/wp-config.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * WooCheck development configuration for WordPress debugging.
+ *
+ * These settings ensure that WooCommerce API interactions are logged to
+ * wp-content/debug.log during development and testing.
+ */
+if ( ! defined( 'WP_DEBUG' ) ) {
+    define( 'WP_DEBUG', true );
+}
+
+if ( ! defined( 'WP_DEBUG_LOG' ) ) {
+    define( 'WP_DEBUG_LOG', true );
+}
+
+if ( ! defined( 'WP_DEBUG_DISPLAY' ) ) {
+    define( 'WP_DEBUG_DISPLAY', false );
+}


### PR DESCRIPTION
## Summary
- log the Recibelo shipment payloads and responses for debugging
- capture Shipit API requests and responses to aid troubleshooting
- ensure WordPress debug logging routes to wp-content/debug.log during development

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d93db6602083329402f3e9af6141ab