### PR TITLE
Add Shipit payload builder and settings UI

### DIFF
--- a/includes/class-wc-check-admin.php
+++ b/includes/class-wc-check-admin.php
@@ -23,7 +23,8 @@ class WC_Check_Admin {
 
     public function register_settings() {
         register_setting( 'woo_check_settings', 'woo_check_recibelo_token' );
-        register_setting( 'woo_check_settings', 'woo_check_shipit_token' );
+        register_setting( 'woo_check_settings', 'wc_check_shipit_email' );
+        register_setting( 'woo_check_settings', 'wc_check_shipit_token' );
 
         add_settings_section(
             'woo_check_section',
@@ -41,7 +42,15 @@ class WC_Check_Admin {
         );
 
         add_settings_field(
-            'woo_check_shipit_token',
+            'wc_check_shipit_email',
+            'Shipit Email',
+            [ $this, 'shipit_email_field_html' ],
+            'woo-check-settings',
+            'woo_check_section'
+        );
+
+        add_settings_field(
+            'wc_check_shipit_token',
             'Shipit Token',
             [ $this, 'shipit_token_field_html' ],
             'woo-check-settings',
@@ -55,9 +64,14 @@ class WC_Check_Admin {
         echo "<input type='text' name='woo_check_recibelo_token' value='$value' class='regular-text' />";
     }
 
+    public function shipit_email_field_html() {
+        $value = esc_attr( get_option( 'wc_check_shipit_email', get_option( 'woo_check_shipit_email', '' ) ) );
+        echo "<input type='email' name='wc_check_shipit_email' value='$value' class='regular-text' />";
+    }
+
     public function shipit_token_field_html() {
-        $value = esc_attr( get_option( 'woo_check_shipit_token', '' ) );
-        echo "<input type='text' name='woo_check_shipit_token' value='$value' class='regular-text' />";
+        $value = esc_attr( get_option( 'wc_check_shipit_token', get_option( 'woo_check_shipit_token', '' ) ) );
+        echo "<input type='text' name='wc_check_shipit_token' value='$value' class='regular-text' />";
     }
 
     public function settings_page_html() {

--- a/includes/class-wc-check-shipit.php
+++ b/includes/class-wc-check-shipit.php
@@ -150,9 +150,10 @@ class WC_Check_Shipit {
             $last_name = $order->get_billing_last_name();
         }
 
+        $receiver_name = trim( $first_name . ' ' . $last_name );
+
         if ( function_exists( 'remove_accents' ) ) {
-            $first_name = remove_accents( $first_name );
-            $last_name  = remove_accents( $last_name );
+            $receiver_name = remove_accents( $receiver_name );
         }
 
         $street_raw = $order->get_shipping_address_1();
@@ -202,8 +203,7 @@ class WC_Check_Shipit {
                     'without_courier'  => false,
                 ],
                 'destiny'   => [
-                    'first_name'   => $first_name,
-                    'last_name'    => $last_name,
+                    'name'         => $receiver_name,
                     'email'        => $order->get_billing_email(),
                     'phone'        => $phone,
                     'street'       => $street,

--- a/includes/class-wc-check-shipit.php
+++ b/includes/class-wc-check-shipit.php
@@ -25,6 +25,10 @@ class WC_Check_Shipit {
             return new WP_Error( 'wc_check_shipit_invalid_order', __( 'Invalid order instance provided.', 'woo-check' ) );
         }
 
+        error_log( 'WooCheck Shipit: Shipping city = ' . (string) $order->get_shipping_city() );
+        error_log( 'WooCheck Shipit: Billing city = ' . (string) $order->get_billing_city() );
+        error_log( 'WooCheck Shipit: All order data = ' . print_r( $order->get_data(), true ) );
+
         $data = $this->build_payload( $order );
 
         if ( empty( $data ) ) {
@@ -157,7 +161,7 @@ class WC_Check_Shipit {
             $phone = $order->get_billing_phone();
         }
 
-        $commune_name = $order->get_shipping_city();
+        $commune_name = $order->get_shipping_city() ?: $order->get_billing_city();
         $commune_id   = $this->get_commune_id( $commune_name );
 
         if ( ! $commune_id ) {

--- a/includes/class-wc-check-shipit.php
+++ b/includes/class-wc-check-shipit.php
@@ -4,108 +4,292 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class WC_Check_Shipit {
+    private $endpoint = 'https://api.shipit.cl/v/shipments';
+    private $email;
+    private $token;
+    private $communes = null;
 
-    /**
-     * Create a Shipit shipment for the provided WooCommerce order.
-     *
-     * @param WC_Order $order Order being fulfilled.
-     *
-     * @return bool Whether the shipment was created successfully.
-     */
+    public function __construct() {
+        $this->email = get_option( 'wc_check_shipit_email' );
+        if ( empty( $this->email ) ) {
+            $this->email = get_option( 'woo_check_shipit_email' );
+        }
+
+        $this->token = get_option( 'wc_check_shipit_token' );
+        if ( empty( $this->token ) ) {
+            $this->token = get_option( 'woo_check_shipit_token' );
+        }
+    }
+
     public function create_shipment( $order ) {
         if ( ! $order instanceof WC_Order ) {
-            return false;
+            return new WP_Error( 'wc_check_shipit_invalid_order', __( 'Invalid order instance provided.', 'woo-check' ) );
         }
 
-        $token = get_option( 'woo_check_shipit_token', '' );
+        $data = $this->build_payload( $order );
 
-        if ( empty( $token ) ) {
-            error_log( 'Shipit token is missing. Skipping shipment.' );
-            return false;
+        if ( empty( $this->email ) || empty( $this->token ) ) {
+            $error = new WP_Error( 'wc_check_shipit_missing_credentials', __( 'Shipit credentials are missing.', 'woo-check' ) );
+            $this->log_api( $data, $error );
+            return $error;
         }
-
-        $comuna     = get_post_meta( $order->get_id(), 'shipping_comuna', true );
-        $commune_id = $this->map_commune_to_id( $comuna );
-        $items      = array_map(
-            static function ( $item ) {
-                return [
-                    'name'  => $item->get_name(),
-                    'qty'   => $item->get_quantity(),
-                    'price' => $item->get_total(),
-                ];
-            },
-            $order->get_items()
-        );
-
-        $data = [
-            'shipment' => [
-                'reference' => 'WC-' . $order->get_id(),
-                'items'     => $items,
-                'sizes'     => [
-                    'width'  => 10,
-                    'height' => 10,
-                    'length' => 10,
-                    'weight' => 1,
-                ],
-                'destiny'   => [
-                    'full_name'    => $order->get_formatted_shipping_full_name(),
-                    'email'        => $order->get_billing_email(),
-                    'phone'        => $order->get_shipping_phone(),
-                    'street'       => $order->get_shipping_address_1(),
-                    'commune_id'   => $commune_id,
-                    'commune_name' => get_post_meta( $order->get_id(), 'billing_comuna', true ),
-                    'kind'         => 'home_delivery',
-                ],
-            ],
-        ];
-
-        $base_url = 'https://api.shipit.cl/v';
-        $endpoint = rtrim( $base_url, '/' ) . '/shipments';
 
         $response = wp_remote_post(
-            $endpoint,
+            $this->endpoint,
             [
                 'headers' => [
-                    'Authorization' => 'Bearer ' . $token,
-                    'Content-Type'  => 'application/json',
+                    'Content-Type'          => 'application/json',
+                    'Accept'                => 'application/vnd.shipit.v4',
+                    'X-Shipit-Email'        => $this->email,
+                    'X-Shipit-Access-Token' => $this->token,
                 ],
                 'body'    => wp_json_encode( $data ),
                 'timeout' => 30,
             ]
         );
 
+        $this->log_api( $data, $response );
+
+        if ( ! is_wp_error( $response ) ) {
+            $body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+            if ( isset( $body['tracking_number'] ) ) {
+                $order->update_meta_data( '_shipit_tracking', sanitize_text_field( $body['tracking_number'] ) );
+                $order->save_meta_data();
+            }
+        }
+
+        return $response;
+    }
+
+    private function build_payload( $order ) {
+        $item_count = 0;
+        $products   = [];
+
+        $default_warehouse = (int) apply_filters( 'wc_check_shipit_default_warehouse_id', 1, $order );
+
+        $dimensions = [
+            'width'  => 0,
+            'height' => 0,
+            'length' => 0,
+            'weight' => 0,
+        ];
+
+        foreach ( $order->get_items() as $item ) {
+            if ( ! $item instanceof WC_Order_Item_Product ) {
+                continue;
+            }
+
+            $quantity = max( 1, (int) $item->get_quantity() );
+            $item_count += $quantity;
+
+            $product = $item->get_product();
+
+            if ( $product instanceof WC_Product ) {
+                $product_weight = (float) $product->get_weight();
+                $product_length = (float) $product->get_length();
+                $product_width  = (float) $product->get_width();
+                $product_height = (float) $product->get_height();
+
+                if ( $product_weight > 0 ) {
+                    $dimensions['weight'] += $product_weight * $quantity;
+                }
+
+                if ( $product_length > 0 ) {
+                    $dimensions['length'] = max( $dimensions['length'], $product_length );
+                }
+
+                if ( $product_width > 0 ) {
+                    $dimensions['width'] = max( $dimensions['width'], $product_width );
+                }
+
+                if ( $product_height > 0 ) {
+                    $dimensions['height'] = max( $dimensions['height'], $product_height );
+                }
+            }
+
+            $sku = $product instanceof WC_Product ? $product->get_sku() : '';
+            if ( '' === $sku ) {
+                $sku = (string) $item->get_product_id();
+            }
+
+            $products[] = [
+                'sku_id'       => $sku,
+                'amount'       => $quantity,
+                'warehouse_id' => (int) apply_filters( 'wc_check_shipit_product_warehouse_id', $default_warehouse, $item, $order ),
+            ];
+        }
+
+        $defaults = [
+            'width'  => 10,
+            'height' => 10,
+            'length' => 10,
+            'weight' => 1,
+        ];
+
+        foreach ( $dimensions as $dimension => $value ) {
+            if ( $value <= 0 ) {
+                $dimensions[ $dimension ] = $defaults[ $dimension ];
+            }
+        }
+
+        $shipping_first_name = $order->get_shipping_first_name();
+        $shipping_last_name  = $order->get_shipping_last_name();
+        $full_name           = trim( $shipping_first_name . ' ' . $shipping_last_name );
+
+        if ( '' === $full_name ) {
+            $full_name = $order->get_formatted_billing_full_name();
+        }
+
+        $street  = $order->get_shipping_address_1();
+        $street2 = $order->get_shipping_address_2();
+
+        if ( '' === $street ) {
+            $street  = $order->get_billing_address_1();
+            $street2 = $order->get_billing_address_2();
+        }
+
+        $phone = $order->get_shipping_phone();
+        if ( '' === $phone ) {
+            $phone = $order->get_billing_phone();
+        }
+
+        $shipping_commune = $order->get_meta( 'shipping_comuna', true );
+        $billing_commune  = $order->get_meta( 'billing_comuna', true );
+
+        $commune          = $this->find_commune( $shipping_commune );
+        $commune_fallback = $this->find_commune( $billing_commune );
+
+        if ( ! $commune && $commune_fallback ) {
+            $commune = $commune_fallback;
+        }
+
+        if ( ! $commune ) {
+            $commune = $this->find_commune( $order->get_shipping_city() );
+        }
+
+        if ( ! $commune ) {
+            $commune = $this->find_commune( $order->get_billing_city() );
+        }
+
+        $commune_name = $commune ? $commune['name'] : ( $shipping_commune ?: $billing_commune ?: $order->get_shipping_city() );
+        $commune_id   = $commune ? (int) $commune['id'] : null;
+
+        $payload = [
+            'shipment' => [
+                'platform'  => 2,
+                'reference' => (string) $order->get_order_number(),
+                'items'     => max( 1, $item_count ),
+                'sizes'     => $dimensions,
+                'courier'   => [
+                    'id'               => 1,
+                    'algorithm'        => 1,
+                    'without_courier'  => false,
+                ],
+                'destiny'   => [
+                    'name'         => $full_name,
+                    'email'        => $order->get_billing_email(),
+                    'phone'        => $phone,
+                    'street'       => $street,
+                    'number'       => $this->extract_street_number( $street ),
+                    'complement'   => $street2,
+                    'commune_id'   => $commune_id,
+                    'commune_name' => $commune_name,
+                    'country_id'   => 1,
+                    'kind'         => 'home_delivery',
+                ],
+                'products'  => $products,
+            ],
+        ];
+
+        return $payload;
+    }
+
+    private function log_api( $data, $response ) {
         error_log( 'Shipit Request: ' . wp_json_encode( $data ) );
 
         if ( is_wp_error( $response ) ) {
-            error_log( 'Shipit HTTP: error ' . $response->get_error_code() );
+            error_log( 'Shipit HTTP: 0 ' . $response->get_error_code() );
             error_log( 'Shipit Response: ' . $response->get_error_message() );
-            error_log( 'Shipit error: ' . $response->get_error_message() );
-            return false;
+            return;
         }
 
         $response_code    = wp_remote_retrieve_response_code( $response );
         $response_message = wp_remote_retrieve_response_message( $response );
+        $response_body    = wp_remote_retrieve_body( $response );
 
-        error_log( 'Shipit HTTP: ' . $response_code . ' ' . $response_message );
-
-        $response_body = wp_remote_retrieve_body( $response );
+        error_log( sprintf( 'Shipit HTTP: %s %s', $response_code, $response_message ) );
         error_log( 'Shipit Response: ' . $response_body );
-
-        $body = json_decode( $response_body, true );
-
-        if ( isset( $body['tracking_number'] ) ) {
-            update_post_meta(
-                $order->get_id(),
-                '_shipit_tracking',
-                sanitize_text_field( $body['tracking_number'] )
-            );
-        }
-
-        return true;
     }
 
-    private function map_commune_to_id( $comuna ) {
-        // TODO: build proper mapping table for Shipit
-        return 308;
+    private function find_commune( $name ) {
+        if ( empty( $name ) ) {
+            return null;
+        }
+
+        $normalized = $this->normalize_commune_name( $name );
+        $communes   = $this->get_communes();
+
+        return $communes[ $normalized ] ?? null;
+    }
+
+    private function get_communes() {
+        if ( null !== $this->communes ) {
+            return $this->communes;
+        }
+
+        $this->communes = [];
+
+        $file = plugin_dir_path( __FILE__ ) . 'communes.json';
+        if ( ! file_exists( $file ) ) {
+            return $this->communes;
+        }
+
+        $contents = file_get_contents( $file );
+        if ( false === $contents ) {
+            return $this->communes;
+        }
+
+        $decoded = json_decode( $contents, true );
+        if ( ! is_array( $decoded ) ) {
+            return $this->communes;
+        }
+
+        foreach ( $decoded as $commune ) {
+            if ( empty( $commune['name'] ) || empty( $commune['id'] ) ) {
+                continue;
+            }
+
+            $normalized = $this->normalize_commune_name( $commune['name'] );
+            $this->communes[ $normalized ] = $commune;
+        }
+
+        return $this->communes;
+    }
+
+    private function normalize_commune_name( $value ) {
+        $value = remove_accents( (string) $value );
+        $value = preg_replace( '/\s+/', ' ', $value );
+        $value = trim( $value );
+
+        if ( function_exists( 'mb_strtoupper' ) ) {
+            $value = mb_strtoupper( $value, 'UTF-8' );
+        } else {
+            $value = strtoupper( $value );
+        }
+
+        return $value;
+    }
+
+    private function extract_street_number( $street ) {
+        if ( empty( $street ) ) {
+            return '';
+        }
+
+        if ( preg_match( '/(\d+)/', $street, $matches ) ) {
+            return $matches[1];
+        }
+
+        return '';
     }
 }

--- a/includes/class-woo-check-shipit-validator.php
+++ b/includes/class-woo-check-shipit-validator.php
@@ -1,0 +1,96 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Validator/Normalizer for Woo-Check → Shipit payload.
+ */
+class WooCheck_Shipit_Validator {
+
+    /**
+     * Ensure names are split correctly.
+     */
+    public static function normalize_name( $first_name, $last_name ) {
+        $first_name = trim( (string) $first_name );
+        $last_name  = trim( (string) $last_name );
+
+        // Fallback: if last name is missing, split full name.
+        if ( '' === $last_name && strpos( $first_name, ' ' ) !== false ) {
+            $parts      = preg_split( '/\s+/', $first_name, 2 );
+            $first_name = $parts[0];
+            $last_name  = isset( $parts[1] ) ? $parts[1] : 'Cliente';
+        }
+
+        if ( '' === $first_name ) {
+            $first_name = 'Cliente';
+        }
+
+        if ( '' === $last_name ) {
+            $last_name = 'Anonimo';
+        }
+
+        return [ $first_name, $last_name ];
+    }
+
+    /**
+     * Ensure phone is in +56 9 format.
+     */
+    public static function normalize_phone( $phone ) {
+        $phone = preg_replace( '/\D+/', '', (string) $phone );
+
+        if ( 9 === strlen( $phone ) && '9' === substr( $phone, 0, 1 ) ) {
+            $phone = '+56' . $phone;
+        } elseif ( 8 === strlen( $phone ) ) {
+            $phone = '+569' . $phone;
+        } elseif ( strncmp( $phone, '56', 2 ) !== 0 ) {
+            $phone = '+56' . $phone;
+        } else {
+            $phone = '+' . $phone;
+        }
+
+        return $phone;
+    }
+
+    /**
+     * Ensure address has street + number + complement.
+     */
+    public static function normalize_address( $address_1, $address_2 ) {
+        $address_1 = (string) $address_1;
+        $address_2 = (string) $address_2;
+
+        $street     = trim( $address_1 );
+        $number     = '';
+        $complement = $address_2;
+
+        if ( preg_match( '/^([\p{L}\s]+)\s+(\d+.*)$/u', $address_1, $matches ) ) {
+            $street = trim( $matches[1] );
+            $number = trim( $matches[2] );
+        }
+
+        if ( '' === $street ) {
+            $street = 'Direccion';
+        }
+
+        if ( '' === $number ) {
+            $number = 'S/N';
+        }
+
+        return [ $street, $number, $complement ];
+    }
+
+    /**
+     * Normalize commune (must always match JSON).
+     */
+    public static function normalize_commune( $comuna ) {
+        $comuna = strtoupper( trim( (string) $comuna ) );
+
+        if ( function_exists( 'remove_accents' ) ) {
+            $comuna = remove_accents( $comuna );
+        }
+
+        if ( '' === $comuna ) {
+            $comuna = 'SANTIAGO';
+        }
+
+        return $comuna;
+    }
+}

--- a/includes/class-woo-check-shipit-validator.php
+++ b/includes/class-woo-check-shipit-validator.php
@@ -2,38 +2,31 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Validator/Normalizer for Woo-Check → Shipit payload.
+ * WooCheck Shipit Validator & Normalizer
  */
 class WooCheck_Shipit_Validator {
 
-    /**
-     * Ensure names are split correctly.
-     */
     public static function normalize_name( $first_name, $last_name ) {
         $first_name = trim( (string) $first_name );
         $last_name  = trim( (string) $last_name );
 
-        // Fallback: if last name is missing, split full name.
+        // Split if last_name missing
         if ( '' === $last_name && strpos( $first_name, ' ' ) !== false ) {
             $parts      = preg_split( '/\s+/', $first_name, 2 );
             $first_name = $parts[0];
-            $last_name  = isset( $parts[1] ) ? $parts[1] : 'Cliente';
+            $last_name  = isset( $parts[1] ) ? $parts[1] : 'Customer';
         }
 
         if ( '' === $first_name ) {
-            $first_name = 'Cliente';
+            $first_name = 'Customer';
         }
-
         if ( '' === $last_name ) {
-            $last_name = 'Anonimo';
+            $last_name = 'Anon';
         }
 
         return [ $first_name, $last_name ];
     }
 
-    /**
-     * Ensure phone is in +56 9 format.
-     */
     public static function normalize_phone( $phone ) {
         $phone = preg_replace( '/\D+/', '', (string) $phone );
 
@@ -41,7 +34,7 @@ class WooCheck_Shipit_Validator {
             $phone = '+56' . $phone;
         } elseif ( 8 === strlen( $phone ) ) {
             $phone = '+569' . $phone;
-        } elseif ( strncmp( $phone, '56', 2 ) !== 0 ) {
+        } elseif ( strpos( $phone, '56' ) !== 0 ) {
             $phone = '+56' . $phone;
         } else {
             $phone = '+' . $phone;
@@ -50,9 +43,6 @@ class WooCheck_Shipit_Validator {
         return $phone;
     }
 
-    /**
-     * Ensure address has street + number + complement.
-     */
     public static function normalize_address( $address_1, $address_2 ) {
         $address_1 = (string) $address_1;
         $address_2 = (string) $address_2;
@@ -69,7 +59,6 @@ class WooCheck_Shipit_Validator {
         if ( '' === $street ) {
             $street = 'Direccion';
         }
-
         if ( '' === $number ) {
             $number = 'S/N';
         }
@@ -77,15 +66,9 @@ class WooCheck_Shipit_Validator {
         return [ $street, $number, $complement ];
     }
 
-    /**
-     * Normalize commune (must always match JSON).
-     */
     public static function normalize_commune( $comuna ) {
-        $comuna = strtoupper( trim( (string) $comuna ) );
-
-        if ( function_exists( 'remove_accents' ) ) {
-            $comuna = remove_accents( $comuna );
-        }
+        $comuna = remove_accents( (string) $comuna );
+        $comuna = strtoupper( trim( $comuna ) );
 
         if ( '' === $comuna ) {
             $comuna = 'SANTIAGO';

--- a/woo-check.php
+++ b/woo-check.php
@@ -18,6 +18,7 @@ require_once plugin_dir_path(__FILE__) . 'functions.php';
 // Load WooCheck logistics dependencies
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-check-admin.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-check-recibelo.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-woo-check-shipit-validator.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-check-shipit.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-check-shipit-webhook.php';
 


### PR DESCRIPTION
## Summary
- replace the Shipit integration with a payload builder that maps communes and logs API requests
- send Shipit requests with the configured credentials and persist tracking numbers on success
- expose Shipit email/token settings in the WooCheck admin panel

## Testing
- php -l includes/class-wc-check-shipit.php
- php -l includes/class-wc-check-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d9b949cb188332a97d4f7184f61578