### PR TITLE
Standardize Recíbelo commune payload to city string

### DIFF
--- a/includes/class-wc-check-recibelo-communes.php
+++ b/includes/class-wc-check-recibelo-communes.php
@@ -18,7 +18,7 @@ class WooCheck_Recibelo_CommuneMapper {
         84  => 'Colina',
         85  => 'Lampa',
         86  => 'Tiltil',
-        87  => 'Santiago centro',
+        87  => 'Santiago Centro',
         88  => 'Vitacura',
         89  => 'San Ramón',
         90  => 'San Miguel',

--- a/includes/class-wc-check-recibelo.php
+++ b/includes/class-wc-check-recibelo.php
@@ -145,23 +145,27 @@ class WooCheck_Recibelo {
             $commune_id   = WooCheck_Recibelo_CommuneMapper::get_commune_id( $lookup_value );
         }
 
-        $delivery_commune = $lookup_value;
+        $final_commune = $lookup_value;
 
         if ( null !== $commune_id ) {
             $canonical_name = WooCheck_Recibelo_CommuneMapper::get_name( $commune_id );
 
             if ( null !== $canonical_name ) {
-                $delivery_commune = $canonical_name;
+                $final_commune = $canonical_name;
             }
         } else {
             error_log( sprintf( 'WooCheck Recibelo: Commune not mapped for order %d - input: %s', $order->get_id(), $lookup_value ) );
         }
 
-        $delivery_commune = (string) $delivery_commune;
-        $shipping['city'] = $delivery_commune;
-        $billing['city']  = $delivery_commune;
+        $final_commune = (string) $final_commune;
 
-        error_log( sprintf( 'WooCheck Recibelo: Final commune for order #%d = %s', $order->get_id(), $delivery_commune ) );
+        // ⚠️ Important:
+        // Recíbelo expects comuna as string in "city".
+        // Shipit expects comuna as numeric "commune_id".
+        $shipping['city'] = $final_commune;
+        $billing['city']  = $final_commune;
+
+        error_log( sprintf( 'WooCheck Recibelo: Final commune for order #%d = %s', $order->get_id(), $final_commune ) );
 
         return [
             'id'                   => $order->get_id(),


### PR DESCRIPTION
## Summary
- ensure the Recíbelo payload always copies the resolved commune name into the billing and shipping city fields
- document the differing commune formats expected by Recíbelo and Shipit within the payload builder
- update the Recíbelo commune catalog casing to match the official listing

## Testing
- php <<'PHP'
<?php
define('ABSPATH', true);
require 'includes/class-wc-check-recibelo-communes.php';
$names = ['Ñuñoa', 'Peñalolén', 'San Joaquín'];
foreach ($names as $name) {
    $id = WooCheck_Recibelo_CommuneMapper::get_commune_id($name);
    $canonical = null !== $id ? WooCheck_Recibelo_CommuneMapper::get_name($id) : 'null';
    echo $name . ' => ' . (null !== $id ? $id : 'null') . ' => ' . $canonical . PHP_EOL;
}
PHP

------
https://chatgpt.com/codex/tasks/task_e_68d9f043d4948332bf6fd460ba8ed720