### PR TITLE
Adjust order information layout and styling

### DIFF
--- a/order-received.css
+++ b/order-received.css
@@ -94,6 +94,29 @@ div#order-information {
     border-radius: 6px;
 }
 
+.order-header {
+    max-width: 1000px;
+    margin: 0 auto 20px;
+    background-color: #000;
+    color: #fff;
+    padding: 20px;
+    border-radius: 6px;
+}
+
+.order-header p {
+    margin: 0;
+}
+
+.order-header .fecha-hora-orden {
+    margin-top: 10px;
+}
+
+p.titulo-seccion {
+    max-width: 1000px;
+    margin: 0 auto;
+    color: inherit;
+}
+
 .woocommerce-column.woocommerce-column--1.woocommerce-column--billing-address.col-1.only-billing {
     width: 100%;
     border-radius: 6px;

--- a/order-received.css
+++ b/order-received.css
@@ -200,7 +200,7 @@ p.titulo-seccion {
     background: black;
     font-weight: 600;
     font-size: 20px;
-    max-width: 250px;
+    max-width: 1000px;
     margin: auto;
     padding: 10px;
 }

--- a/order-received.css
+++ b/order-received.css
@@ -87,7 +87,7 @@ ul.order-products {
 }
 
 div#order-information {
-    max-width: 800px;
+    max-width: 1000px;
     margin: auto;
     background: #f9f9f9;
     padding: 20px 0px;
@@ -216,13 +216,18 @@ div#info-entrega {
     border: 1px solid black;
     padding: 20px;
     text-align: center;
-    margin-top: 30px;
     margin-bottom: 40px;
 }
 
 div#info-entrega > p {
     margin-top: 0px;
     font-size: 12px;
+}
+
+p.fecha-hora-orden {
+    color: #ffffff;
+    margin-top: 0px;
+    margin-bottom: 0px;
 }
 
 div#estimacion-entrega {

--- a/order-received.css
+++ b/order-received.css
@@ -109,6 +109,7 @@ div#order-information {
 
 .order-header .fecha-hora-orden {
     margin-top: 10px;
+    font-size: 12px;
 }
 
 p.titulo-seccion {
@@ -251,6 +252,7 @@ p.fecha-hora-orden {
     color: #ffffff;
     margin-top: 0px;
     margin-bottom: 0px;
+    font-size: 12px;
 }
 
 div#estimacion-entrega {

--- a/templates/checkout/order-received.php
+++ b/templates/checkout/order-received.php
@@ -48,10 +48,18 @@ $order = wc_get_order($order_id);
 
 
 <?php if ($order) : ?>
+    <?php
+        $order_datetime_display = '';
+        if ($order->get_date_created()) {
+            $order_datetime_display = $order->get_date_created()->date_i18n('d-m-Y H:i:s');
+        }
+    ?>
     <div id="order-information">
         <div class="order-header">
             <p class="titulo-seccion">Número de orden: <?php echo esc_html($order->get_id()); ?></p>
-            <p class="fecha-hora-orden">Fecha y hora de la orden: 29-09-2025 13:06:43</p>
+            <?php if (!empty($order_datetime_display)) : ?>
+                <p class="fecha-hora-orden">Fecha y hora de la orden: <?php echo esc_html($order_datetime_display); ?></p>
+            <?php endif; ?>
         </div>
 
         <?php
@@ -155,8 +163,6 @@ if ($order) {
     $metodoPago = $order->get_payment_method(); // Método de pago (por ejemplo: 'bacs', 'stripe', etc.)
 
     // Muestra la fecha y hora de la orden
-    $fechaHoraOrden = (new DateTime($horaCompra))->format('d-m-Y H:i:s');
-
     $diasEntrega = calcular_dias_entrega($regionCode, $horaCompra, $metodoPago, $order_id);
 
     // Genera el contenido dentro de un <div> con id="info-entrega"

--- a/templates/checkout/order-received.php
+++ b/templates/checkout/order-received.php
@@ -49,8 +49,10 @@ $order = wc_get_order($order_id);
 
 <?php if ($order) : ?>
     <div id="order-information">
-        <p class="titulo-seccion">Número de orden: <?php echo esc_html($order->get_id()); ?></p>
-        <p class="fecha-hora-orden">Fecha y hora de la orden: 29-09-2025 13:06:43</p>
+        <div class="order-header">
+            <p class="titulo-seccion">Número de orden: <?php echo esc_html($order->get_id()); ?></p>
+            <p class="fecha-hora-orden">Fecha y hora de la orden: 29-09-2025 13:06:43</p>
+        </div>
 
         <?php
 function calcular_dias_entrega($regionCode, $horaCompra, $metodoPago, $order_id) {
@@ -159,7 +161,6 @@ if ($order) {
 
     // Genera el contenido dentro de un <div> con id="info-entrega"
     echo "<div id='info-entrega'>";
-    echo "<p>Fecha y hora de la orden: $fechaHoraOrden</p>";
 
     if (is_string($diasEntrega)) {
         // Regla especial o mensaje de espera devuelve un mensaje directo

--- a/templates/checkout/order-received.php
+++ b/templates/checkout/order-received.php
@@ -50,6 +50,7 @@ $order = wc_get_order($order_id);
 <?php if ($order) : ?>
     <div id="order-information">
         <p class="titulo-seccion">Número de orden: <?php echo esc_html($order->get_id()); ?></p>
+        <p class="fecha-hora-orden">Fecha y hora de la orden: 29-09-2025 13:06:43</p>
 
         <?php
 function calcular_dias_entrega($regionCode, $horaCompra, $metodoPago, $order_id) {


### PR DESCRIPTION
## Summary
- expand the order information container to a 1000px max width for a wider layout
- remove the top margin from the delivery info block and style the order timestamp text in white
- display the order timestamp directly beneath the order number on the order received page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbc12460bc833286bb9d87b3487fc4