### PR TITLE
Add collapsible bank transfer details with copy support

### DIFF
--- a/order-received.css
+++ b/order-received.css
@@ -95,6 +95,110 @@ div#order-information {
     border-radius: 6px;
 }
 
+.bank-transfer-info {
+    max-width: 1000px;
+    margin: 20px auto;
+    border: 1px solid #d9d9d9;
+    border-radius: 8px;
+    background-color: #ffffff;
+    overflow: hidden;
+}
+
+.bank-transfer-toggle {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    background-color: #f0f0f0;
+    color: #000000;
+    font-weight: 600;
+    font-size: 16px;
+    padding: 16px 20px;
+    border: none;
+    cursor: pointer;
+    transition: background-color 0.2s ease-in-out;
+}
+
+.bank-transfer-toggle:hover,
+.bank-transfer-toggle:focus {
+    background-color: #e2e2e2;
+}
+
+.bank-transfer-icon {
+    font-size: 20px;
+    line-height: 1;
+}
+
+.bank-transfer-content {
+    padding: 16px 20px 20px;
+    text-align: left;
+}
+
+.bank-transfer-list {
+    list-style: none;
+    margin: 0 0 16px;
+    padding: 0;
+    display: grid;
+    gap: 12px;
+}
+
+.bank-transfer-item {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 8px;
+}
+
+.bank-transfer-label {
+    font-weight: 600;
+    color: #000000;
+}
+
+.bank-transfer-value a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.bank-transfer-value a:hover,
+.bank-transfer-value a:focus {
+    text-decoration: underline;
+}
+
+.bank-transfer-copy {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: 18px;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4px;
+    border-radius: 4px;
+    transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out;
+}
+
+.bank-transfer-copy:hover,
+.bank-transfer-copy:focus {
+    background-color: #f0f0f0;
+    color: #000000;
+}
+
+.bank-transfer-copy--success {
+    color: #2e7d32;
+}
+
+.bank-transfer-important {
+    margin-bottom: 8px;
+    font-weight: 500;
+}
+
+.bank-transfer-reminder {
+    margin: 0;
+    font-weight: 500;
+}
+
 .order-header {
     max-width: 1000px;
     margin: 0 auto 20px;
@@ -145,6 +249,14 @@ p.titulo-seccion {
     div#order-information {
         max-width: 90%;
 
+    }
+    .bank-transfer-item {
+        grid-template-columns: 1fr;
+        justify-items: flex-start;
+    }
+
+    .bank-transfer-copy {
+        padding-left: 0;
     }
     .woocommerce-customer-details {
         max-width: 90%;

--- a/templates/checkout/order-received.php
+++ b/templates/checkout/order-received.php
@@ -137,17 +137,121 @@ function calcular_dias_entrega($regionCode, $horaCompra, $metodoPago, $order_id)
 
     // Si el método de pago es transferencia bancaria (bacs), muestra el mensaje de espera con datos bancarios
     if ($metodoPago === 'bacs') {
-        return "
-            <strong>Datos para realizar la transferencia:</strong><br>
-           
-                <p><strong>Nombre:</strong> Villegas y Compañía SpA</p>
-                <p><strong>RUT:</strong> 77593240-6</p>
-                <p><strong>Banco:</strong> Banco Itaú</p>
-                <p><strong>Cuenta Corriente:</strong> 0224532529</p>
-                <p><strong>Correo:</strong> <a href='mailto:villeguistas@gmail.com'>villeguistas@gmail.com</a></p>
-            <p><strong>IMPORTANTE:</strong> Enviar comprobante al correo indicado. Sin comprobante no podemos procesar la orden.</p>
-            <p>Indique el número de orden (<strong>$order_id</strong>) y su nombre en el mensaje de la transferencia.</p>
-        ";
+        return <<<HTML
+            <div class="bank-transfer-info">
+                <button class="bank-transfer-toggle" type="button" aria-expanded="false">
+                    <span class="bank-transfer-title">Datos Transferencia Bancaria</span>
+                    <span class="bank-transfer-icon" aria-hidden="true">+</span>
+                </button>
+                <div class="bank-transfer-content" hidden>
+                    <ul class="bank-transfer-list">
+                        <li class="bank-transfer-item">
+                            <span class="bank-transfer-label">Nombre:</span>
+                            <span class="bank-transfer-value">Villegas y Compañía SpA</span>
+                            <button class="bank-transfer-copy" type="button" data-copy="Villegas y Compañía SpA" aria-label="Copiar nombre">
+                                <span class="bank-transfer-copy-icon" aria-hidden="true">📋</span>
+                            </button>
+                        </li>
+                        <li class="bank-transfer-item">
+                            <span class="bank-transfer-label">RUT:</span>
+                            <span class="bank-transfer-value">77593240-6</span>
+                            <button class="bank-transfer-copy" type="button" data-copy="77593240-6" aria-label="Copiar RUT">
+                                <span class="bank-transfer-copy-icon" aria-hidden="true">📋</span>
+                            </button>
+                        </li>
+                        <li class="bank-transfer-item">
+                            <span class="bank-transfer-label">Banco:</span>
+                            <span class="bank-transfer-value">Banco Itaú</span>
+                            <button class="bank-transfer-copy" type="button" data-copy="Banco Itaú" aria-label="Copiar banco">
+                                <span class="bank-transfer-copy-icon" aria-hidden="true">📋</span>
+                            </button>
+                        </li>
+                        <li class="bank-transfer-item">
+                            <span class="bank-transfer-label">Cuenta Corriente:</span>
+                            <span class="bank-transfer-value">0224532529</span>
+                            <button class="bank-transfer-copy" type="button" data-copy="0224532529" aria-label="Copiar cuenta corriente">
+                                <span class="bank-transfer-copy-icon" aria-hidden="true">📋</span>
+                            </button>
+                        </li>
+                        <li class="bank-transfer-item">
+                            <span class="bank-transfer-label">Correo:</span>
+                            <span class="bank-transfer-value"><a href="mailto:villeguistas@gmail.com">villeguistas@gmail.com</a></span>
+                            <button class="bank-transfer-copy" type="button" data-copy="villeguistas@gmail.com" aria-label="Copiar correo">
+                                <span class="bank-transfer-copy-icon" aria-hidden="true">📋</span>
+                            </button>
+                        </li>
+                    </ul>
+                    <p class="bank-transfer-important"><strong>IMPORTANTE:</strong> Enviar comprobante al correo indicado. Sin comprobante no podemos procesar la orden.</p>
+                    <p class="bank-transfer-reminder">Indique el número de orden (<strong>{$order_id}</strong>) y su nombre en el mensaje de la transferencia.</p>
+                </div>
+            </div>
+            <script>
+                (function () {
+                    if (window.bankTransferInfoInitialized) {
+                        return;
+                    }
+                    window.bankTransferInfoInitialized = true;
+
+                    const initBankTransferInfo = function () {
+                        const toggles = document.querySelectorAll('.bank-transfer-toggle');
+                        toggles.forEach(function (toggle) {
+                            toggle.addEventListener('click', function () {
+                                const content = this.nextElementSibling;
+                                const icon = this.querySelector('.bank-transfer-icon');
+                                const isExpanded = this.getAttribute('aria-expanded') === 'true';
+
+                                if (isExpanded) {
+                                    this.setAttribute('aria-expanded', 'false');
+                                    content.setAttribute('hidden', '');
+                                    if (icon) {
+                                        icon.textContent = '+';
+                                    }
+                                } else {
+                                    this.setAttribute('aria-expanded', 'true');
+                                    content.removeAttribute('hidden');
+                                    if (icon) {
+                                        icon.textContent = '−';
+                                    }
+                                }
+                            });
+                        });
+
+                        const copyButtons = document.querySelectorAll('.bank-transfer-copy');
+                        copyButtons.forEach(function (button) {
+                            button.addEventListener('click', function () {
+                                const self = this;
+                                const valueToCopy = self.getAttribute('data-copy');
+                                const icon = self.querySelector('.bank-transfer-copy-icon');
+                                const originalIcon = icon ? icon.textContent : '';
+
+                                navigator.clipboard.writeText(valueToCopy)
+                                    .then(function () {
+                                        if (icon) {
+                                            icon.textContent = '✓';
+                                        }
+                                        self.classList.add('bank-transfer-copy--success');
+                                        setTimeout(function () {
+                                            if (icon) {
+                                                icon.textContent = originalIcon || '📋';
+                                            }
+                                            button.classList.remove('bank-transfer-copy--success');
+                                        }, 2000);
+                                    })
+                                    .catch(function (error) {
+                                        console.error('No se pudo copiar el texto:', error);
+                                    });
+                            });
+                        });
+                    };
+
+                    if (document.readyState === 'loading') {
+                        document.addEventListener('DOMContentLoaded', initBankTransferInfo);
+                    } else {
+                        initBankTransferInfo();
+                    }
+                })();
+            </script>
+        HTML;
     }
 
     // Obtén los días base para la región


### PR DESCRIPTION
## Summary
- replace the static bank transfer notice with a collapsible block that exposes the payment details on demand
- add clipboard copy buttons for each bank detail and toggle logic to show or hide the section
- style the new collapsible and copy controls for desktop and mobile layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1411e1f08332a20bd3214a57b656