### PR TITLE
Add Shipit tracking AJAX polling on order received page

### DIFF
--- a/assets/js/woocheck-tracking.js
+++ b/assets/js/woocheck-tracking.js
@@ -1,0 +1,30 @@
+jQuery(document).ready(function($) {
+    function refreshTracking() {
+        var $container = $('#tracking-status');
+
+        if ($container.length === 0) {
+            return;
+        }
+
+        var orderId = $container.data('order-id');
+
+        if (!orderId || typeof WooCheckAjax === 'undefined' || !WooCheckAjax.ajax_url) {
+            return;
+        }
+
+        $.post(WooCheckAjax.ajax_url, {
+            action: 'woocheck_shipit_status',
+            order_id: orderId
+        }, function(response) {
+            if (response.success && response.data.message) {
+                $container.find('.tracking-message').text(response.data.message);
+            } else {
+                $container.find('.tracking-message').text("Estamos consultando el estado de este envío...");
+            }
+        });
+    }
+
+    // Run immediately + every 20s
+    refreshTracking();
+    setInterval(refreshTracking, 20000);
+});

--- a/templates/checkout/order-received.php
+++ b/templates/checkout/order-received.php
@@ -278,19 +278,30 @@ $order = wc_get_order($order_id);
                 $has_tracking = !empty($tracking_number);
 
                 if ($has_tracking) :
+                    $normalized_provider = strtolower((string) $tracking_provider);
                 ?>
-                    <p id="tracking-info" data-has-tracking="1">
-                        <strong>Tracking:</strong> <?php echo esc_html($tracking_number); ?>
-                        <?php if (!empty($tracking_provider)) : ?>
-                            (
-                            <?php if (strtolower((string) $tracking_provider) === 'recibelo') : ?>
-                                <a href="https://recibelo.cl/seguimiento" target="_blank" rel="noopener noreferrer" style="color: #fff;">Recíbelo</a>
-                            <?php else : ?>
-                                <?php echo esc_html(ucfirst($tracking_provider)); ?>
+                    <?php if ($normalized_provider === 'shipit') : ?>
+                        <div id="tracking-status" data-order-id="<?php echo esc_attr($order->get_id()); ?>">
+                            <p>
+                                <strong>Tracking:</strong>
+                                <?php echo esc_html($tracking_number); ?> (Shipit)
+                            </p>
+                            <p class="tracking-message"><?php esc_html_e('Estamos consultando el estado de este envío...', 'woo-check'); ?></p>
+                        </div>
+                    <?php else : ?>
+                        <p id="tracking-info" data-has-tracking="1">
+                            <strong>Tracking:</strong> <?php echo esc_html($tracking_number); ?>
+                            <?php if (!empty($tracking_provider)) : ?>
+                                (
+                                <?php if ($normalized_provider === 'recibelo') : ?>
+                                    <a href="https://recibelo.cl/seguimiento" target="_blank" rel="noopener noreferrer" style="color: #fff;">Recíbelo</a>
+                                <?php else : ?>
+                                    <?php echo esc_html(ucfirst($tracking_provider)); ?>
+                                <?php endif; ?>
+                                )
                             <?php endif; ?>
-                            )
-                        <?php endif; ?>
-                    </p>
+                        </p>
+                    <?php endif; ?>
                 <?php else : ?>
                     <p id="tracking-info" data-has-tracking="0"><em>Tu número de seguimiento estará disponible pronto.</em></p>
                 <?php endif; ?>

--- a/woo-check.php
+++ b/woo-check.php
@@ -468,6 +468,9 @@ function wc_check_resend_order_to_recibelo( $order ) {
 add_action( 'wp_ajax_get_tracking_info', 'woocheck_get_tracking_info' );
 add_action( 'wp_ajax_nopriv_get_tracking_info', 'woocheck_get_tracking_info' );
 
+add_action( 'wp_ajax_woocheck_shipit_status', [ 'WC_Check_Shipit', 'ajax_get_tracking_status' ] );
+add_action( 'wp_ajax_nopriv_woocheck_shipit_status', [ 'WC_Check_Shipit', 'ajax_get_tracking_status' ] );
+
 function woocheck_get_tracking_info() {
     $order_id = isset( $_POST['order_id'] ) ? absint( wp_unslash( $_POST['order_id'] ) ) : 0;
 
@@ -1006,6 +1009,26 @@ function woo_check_enqueue_assets() {
         );
     }
 }
+
+add_action( 'wp_enqueue_scripts', function() {
+    if ( function_exists( 'is_order_received_page' ) && is_order_received_page() ) {
+        wp_enqueue_script(
+            'woocheck-tracking',
+            plugins_url( 'assets/js/woocheck-tracking.js', __FILE__ ),
+            [ 'jquery' ],
+            '1.0',
+            true
+        );
+
+        wp_localize_script(
+            'woocheck-tracking',
+            'WooCheckAjax',
+            [
+                'ajax_url' => admin_url( 'admin-ajax.php' ),
+            ]
+        );
+    }
+} );
 
 add_action('admin_enqueue_scripts', 'woo_check_enqueue_admin_order_assets');
 function woo_check_enqueue_admin_order_assets($hook) {


### PR DESCRIPTION
## Summary
- add Shipit tracking lookup helpers including an AJAX endpoint for polling status updates
- enqueue a frontend polling script on the order received page and register the new AJAX routes
- render a Shipit tracking placeholder and live status message container on the thank you template

## Testing
- php -l includes/class-wc-check-shipit.php
- php -l woo-check.php
- php -l templates/checkout/order-received.php

------
https://chatgpt.com/codex/tasks/task_e_68dc5553a2e08332928a2fab3446d18c