### PR TITLE
Ensure tracking link displays in white

### DIFF
--- a/order-received.css
+++ b/order-received.css
@@ -386,3 +386,12 @@ div#info-extra-envio {
 p.recibelo-tracking-status {
     margin: 10px;
 }
+
+p.tracking-link a {
+    color: #ffffff;
+}
+
+p.tracking-link a:focus,
+p.tracking-link a:hover {
+    color: #ffffff;
+}


### PR DESCRIPTION
## Summary
- set the tracking link text color to white to ensure it remains legible on dark backgrounds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc60812b248332a6576b3be6c90899