### PR TITLE
Set checkout page background image

### DIFF
--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -12,6 +12,12 @@ form.checkout.woocommerce-checkout {
     margin: auto;
 }
 
+body.woocommerce-checkout {
+    background: url(https://elvillegas.cl/wp-content/uploads/2024/05/Nunork4.jpg);
+    background-size: cover;
+    background-repeat: no-repeat;
+}
+
 /* Example: Style for billing fields */
 .woocommerce-checkout #customer_details .col-1,
 .woocommerce-checkout #customer_details .col-2 {


### PR DESCRIPTION
## Summary
- set the WooCommerce checkout page body background to the specified image and ensure it covers the viewport

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc796907b08332aa1eef0b34200f54