### PR TITLE
Adjust checkout modal width

### DIFF
--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -66,8 +66,14 @@ h1.alignwide.wp-block-post-title,
     width: 100%;
 }
 
-.woocommerce-form-coupon-toggle .woocommerce-info {
-    background: linear-gradient(90deg, #fcff9e 0%, #c67700 100%);
+.woocommerce-form-login-toggle > .wc-block-components-notice-banner,
+.woocommerce-form-login-toggle > .woocommerce-info {
+    background-image: linear-gradient(to right, #c1c161 0%, #c1c161 0%, #d4d4b1 100%);
+}
+
+.woocommerce-form-coupon-toggle > .wc-block-components-notice-banner,
+.woocommerce-form-coupon-toggle > .woocommerce-info {
+    background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
     border: 0;
 }
 
@@ -382,12 +388,8 @@ table.shop_table.woocommerce-checkout-review-order-table {
 }
 
 .wc-block-components-notice-banner.is-info {
-    background-image: radial-gradient(at top center, rgba(255, 255, 255, 0.03) 0%, rgba(0, 0, 0, 0.03) 100%), linear-gradient(to top, rgba(255, 255, 255, 0.1) 0%, rgba(143, 152, 157, 0.6) 100%);
+    background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
     border-color: #ffe16e;
-}
-
-.woocommerce-form-login-toggle.wc-block-components-notice-banner {
-    background-image: radial-gradient(at top center, rgba(255, 255, 255, 0.03) 0%, rgba(0, 0, 0, 0.03) 100%), linear-gradient(to top, rgba(255, 255, 255, 0.1) 0%, rgba(143, 152, 157, 0.6) 100%);
 }
 
 .wc-block-components-notice-banner.is-info>svg {

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -66,9 +66,17 @@ h1.alignwide.wp-block-post-title,
     width: 100%;
 }
 
+
 .woocommerce-form-login-toggle > .wc-block-components-notice-banner,
 .woocommerce-form-login-toggle > .woocommerce-info {
-    background-image: linear-gradient(to right, #c1c161 0%, #c1c161 0%, #d4d4b1 100%);
+    background-image: radial-gradient(at top center, rgba(255, 255, 255, 0.03) 0%, rgba(0, 0, 0, 0.03) 100%),
+        linear-gradient(to top, rgba(255, 255, 255, 0.1) 0%, rgba(143, 152, 157, 0.6) 100%);
+}
+
+.woocommerce-form-login-toggle.wc-block-components-notice-banner,
+.woocommerce-form-login-toggle.woocommerce-info {
+    background-image: radial-gradient(at top center, rgba(255, 255, 255, 0.03) 0%, rgba(0, 0, 0, 0.03) 100%),
+        linear-gradient(to top, rgba(255, 255, 255, 0.1) 0%, rgba(143, 152, 157, 0.6) 100%);
 }
 
 .woocommerce-form-coupon-toggle > .wc-block-components-notice-banner,
@@ -78,7 +86,7 @@ h1.alignwide.wp-block-post-title,
 }
 
 tr.cart-discount {
-    background: linear-gradient(314deg, #fff19e 0%, #dcc269 100%);
+    background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
 }
 
 #woocommerce-checkout-form-coupon .form-row-first {
@@ -259,6 +267,14 @@ p#billing_last_name_field {
     float: right;
 }
 
+p#shipping_first_name_field {
+    width: 47%;
+}
+
+p#shipping_last_name_field {
+    float: right;
+}
+
 #shipping_country_field {
     display: none;
 }
@@ -388,7 +404,7 @@ table.shop_table.woocommerce-checkout-review-order-table {
 }
 
 .wc-block-components-notice-banner.is-info {
-    background: linear-gradient(314deg, #fff19e 0%, #dcc269 100%);
+    background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
     border-color: #ffe16e;
 }
 

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -66,6 +66,15 @@ h1.alignwide.wp-block-post-title,
     border: 0;
 }
 
+.wc-block-components-notice-banner.is-info {
+    background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
+    border-color: #ffe16e;
+}
+
+tr.cart-discount {
+    background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
+}
+
 #woocommerce-checkout-form-coupon .form-row-first {
     width: 100% !important;
     float: none;

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -28,6 +28,7 @@ form.checkout.woocommerce-checkout {
 #woocommerce-checkout-form h3 {
     font-family: sans-serif;
     font-weight: 900;
+    margin-bottom: 5px;
 }
 
 h1.alignwide.wp-block-post-title,
@@ -86,7 +87,7 @@ h1.alignwide.wp-block-post-title,
 }
 
 tr.cart-discount {
-    background: linear-gradient(314deg, #fff19e 0%, #dcc269 100%);
+    background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
 }
 
 .woocommerce form .form-row.woocommerce-validated input.input-text,
@@ -293,7 +294,7 @@ label.woocommerce-form__label.woocommerce-form__label-for-checkbox.checkbox {
     font-size: 15px;
     border: 1px solid #c8c8c8;
     padding: 5px 10px;
-    border-radius: 4px;
+    border-radius: 19px;
     background: #efefef;
 }
 
@@ -413,7 +414,7 @@ table.shop_table.woocommerce-checkout-review-order-table {
 }
 
 .wc-block-components-notice-banner.is-info {
-    background: linear-gradient(314deg, #fff19e 0%, #dcc269 100%);
+    background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
     border-color: #ffe16e;
 }
 

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -116,7 +116,7 @@ input#coupon_code {
 
 .checkout-modal__panel {
     position: relative;
-    width: 320px;
+    width: 380px;
     max-height: calc(100vh - 40px);
     overflow-y: auto;
     background: #ffffff;
@@ -187,7 +187,7 @@ input#coupon_code {
     }
 
     .checkout-modal__panel {
-        width: min(100%, 320px);
+        width: min(100%, 380px);
         padding: 24px 20px;
     }
 

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -148,6 +148,14 @@ input#coupon_code {
     margin: 0;
 }
 
+#checkout-login-modal .woocommerce-form.woocommerce-form-login.login p.form-row.form-row-last {
+    width: 100%;
+}
+
+#checkout-login-modal .woocommerce-form.woocommerce-form-login.login button.woocommerce-button.button.woocommerce-form-login__submit.wp-element-button {
+    margin-bottom: 10px;
+}
+
 .checkout-modal__close {
     position: absolute;
     top: 12px;

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -156,6 +156,10 @@ input#coupon_code {
     margin-bottom: 10px;
 }
 
+form.woocommerce-form.woocommerce-form-login.login {
+    background: #ffffff;
+}
+
 .checkout-modal__close {
     position: absolute;
     top: 12px;

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -303,6 +303,10 @@ table.shop_table.woocommerce-checkout-review-order-table {
     border: 2px solid #c9c9c9;
 }
 
+#order_review thead {
+    background: #ebebeb;
+}
+
 #add_payment_method #payment, .woocommerce-cart #payment, .woocommerce-checkout #payment {
     background: #ebebeb;
     border-radius: 5px;

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -163,7 +163,7 @@ input#coupon_code {
 }
 
 form.woocommerce-form.woocommerce-form-login.login {
-    background: #ffffff;
+    background: white;
 }
 
 .checkout-modal__close {

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -388,7 +388,7 @@ table.shop_table.woocommerce-checkout-review-order-table {
 }
 
 .wc-block-components-notice-banner.is-info {
-    background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
+    background: linear-gradient(90deg, #fdff9e 0%, #614016 100%);
     border-color: #ffe16e;
 }
 

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -212,6 +212,14 @@ p#billing_country_field {
     display: none;
 }
 
+p#billing_first_name_field {
+    width: 47%;
+}
+
+p#billing_last_name_field {
+    float: right;
+}
+
 #shipping_country_field {
     display: none;
 }

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -78,7 +78,7 @@ h1.alignwide.wp-block-post-title,
 }
 
 tr.cart-discount {
-    background: linear-gradient(90deg, #fdff9e 0%, #614016 100%);
+    background: linear-gradient(314deg, #fff19e 0%, #dcc269 100%);
 }
 
 #woocommerce-checkout-form-coupon .form-row-first {
@@ -388,7 +388,7 @@ table.shop_table.woocommerce-checkout-review-order-table {
 }
 
 .wc-block-components-notice-banner.is-info {
-    background: linear-gradient(90deg, #fdff9e 0%, #614016 100%);
+    background: linear-gradient(314deg, #fff19e 0%, #dcc269 100%);
     border-color: #ffe16e;
 }
 

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -25,6 +25,11 @@ form.checkout.woocommerce-checkout {
     margin: 0 auto 50px;
 }
 
+#woocommerce-checkout-form h3 {
+    font-family: sans-serif;
+    font-weight: 900;
+}
+
 h1.alignwide.wp-block-post-title,
 #checkout-page-title {
     color: white;
@@ -64,11 +69,6 @@ h1.alignwide.wp-block-post-title,
 .woocommerce-form-coupon-toggle .woocommerce-info {
     background: linear-gradient(90deg, #fcff9e 0%, #c67700 100%);
     border: 0;
-}
-
-.wc-block-components-notice-banner.is-info {
-    background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
-    border-color: #ffe16e;
 }
 
 tr.cart-discount {
@@ -382,8 +382,12 @@ table.shop_table.woocommerce-checkout-review-order-table {
 }
 
 .wc-block-components-notice-banner.is-info {
-    background: linear-gradient(90deg, #fcff9e 0%, #c67700 100%);
+    background-image: radial-gradient(at top center, rgba(255, 255, 255, 0.03) 0%, rgba(0, 0, 0, 0.03) 100%), linear-gradient(to top, rgba(255, 255, 255, 0.1) 0%, rgba(143, 152, 157, 0.6) 100%);
     border-color: #ffe16e;
+}
+
+.woocommerce-form-login-toggle.wc-block-components-notice-banner {
+    background-image: radial-gradient(at top center, rgba(255, 255, 255, 0.03) 0%, rgba(0, 0, 0, 0.03) 100%), linear-gradient(to top, rgba(255, 255, 255, 0.1) 0%, rgba(143, 152, 157, 0.6) 100%);
 }
 
 .wc-block-components-notice-banner.is-info>svg {

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -89,6 +89,11 @@ tr.cart-discount {
     background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
 }
 
+.woocommerce form .form-row.woocommerce-validated input.input-text,
+.woocommerce form .form-row.woocommerce-validated select {
+    border-color: #dec46c;
+}
+
 #woocommerce-checkout-form-coupon .form-row-first {
     width: 100% !important;
     float: none;

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -176,7 +176,16 @@ input#coupon_code {
 .woocommerce-form-login-toggle,
 .woocommerce-form-coupon-toggle {
     width: 100%;
-    margin: 0;
+}
+
+@media (min-width: 768px) {
+    .woocommerce-form-login-toggle {
+        margin-right: 10px;
+    }
+
+    .woocommerce-form-coupon-toggle {
+        margin-left: 0;
+    }
 }
 
 @media (max-width: 767px) {
@@ -198,9 +207,12 @@ input#coupon_code {
         width: 100%;
     }
 
-    .woocommerce-form-login-toggle,
+    .woocommerce-form-login-toggle {
+        margin-right: 0;
+    }
+
     .woocommerce-form-coupon-toggle {
-        margin: 0;
+        margin-left: 10px;
     }
 
     .checkout-modal__panel {

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -78,7 +78,7 @@ h1.alignwide.wp-block-post-title,
 }
 
 tr.cart-discount {
-    background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
+    background: linear-gradient(90deg, #fdff9e 0%, #614016 100%);
 }
 
 #woocommerce-checkout-form-coupon .form-row-first {

--- a/woo-check-style.css
+++ b/woo-check-style.css
@@ -86,7 +86,7 @@ h1.alignwide.wp-block-post-title,
 }
 
 tr.cart-discount {
-    background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
+    background: linear-gradient(314deg, #fff19e 0%, #dcc269 100%);
 }
 
 .woocommerce form .form-row.woocommerce-validated input.input-text,
@@ -409,7 +409,7 @@ table.shop_table.woocommerce-checkout-review-order-table {
 }
 
 .wc-block-components-notice-banner.is-info {
-    background: linear-gradient(90deg, #fcff9e 0%, #ffb340 100%);
+    background: linear-gradient(314deg, #fff19e 0%, #dcc269 100%);
     border-color: #ffe16e;
 }
 


### PR DESCRIPTION
## Summary
- expand the checkout modal panel base width to 380px
- update the responsive rule to respect the wider panel size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd48b3ab348332a3263dfbbdbbc94e