### PR TITLE
Fix order received flip card addresses and styling

### DIFF
--- a/order-received.css
+++ b/order-received.css
@@ -157,7 +157,7 @@ div#order-information {
 }
 
 .order-address-flip-card .flip-card-face.flip-card-back {
-    background-image: linear-gradient(135deg, #f1ca74 10%, #a64db6 100%);
+    background: linear-gradient(314deg, rgb(255, 241, 158) 0%, rgb(220, 194, 105) 100%);
     color: #3d3d3d;
 }
 

--- a/templates/checkout/order-received.php
+++ b/templates/checkout/order-received.php
@@ -68,14 +68,14 @@ $order = wc_get_order($order_id);
         }
 
         $format_address_block = function ($type) use ($order) {
-            $lines = [];
+            $lines       = [];
+            $address_key = $type === 'billing' ? 'billing' : 'shipping';
 
-            if ($type === 'billing') {
+            if ($address_key === 'billing') {
                 $first_name = $order->get_billing_first_name();
                 $last_name  = $order->get_billing_last_name();
                 $address_1  = $order->get_billing_address_1();
                 $address_2  = $order->get_billing_address_2();
-                $comuna     = get_post_meta($order->get_id(), 'billing_comuna', true);
                 $state      = $order->get_billing_state();
                 $phone      = $order->get_billing_phone();
                 $email      = $order->get_billing_email();
@@ -84,10 +84,24 @@ $order = wc_get_order($order_id);
                 $last_name  = $order->get_shipping_last_name();
                 $address_1  = $order->get_shipping_address_1();
                 $address_2  = $order->get_shipping_address_2();
-                $comuna     = get_post_meta($order->get_id(), 'shipping_comuna', true);
                 $state      = $order->get_shipping_state();
                 $phone      = $order->get_shipping_phone();
                 $email      = '';
+            }
+
+            $comuna = '';
+            if (function_exists('woo_check_get_order_comuna_value')) {
+                $comuna = woo_check_get_order_comuna_value($order, $address_key);
+            }
+
+            if ('' === trim((string) $comuna)) {
+                $comuna = get_post_meta($order->get_id(), sprintf('%s_comuna', $address_key), true);
+            }
+
+            if ('' === trim((string) $comuna)) {
+                $comuna = $address_key === 'billing'
+                    ? $order->get_billing_city()
+                    : $order->get_shipping_city();
             }
 
             $full_name = trim(trim((string) $first_name) . ' ' . trim((string) $last_name));


### PR DESCRIPTION
## Summary
- ensure the order received flip card resolves billing and shipping comunas from the active order with fallbacks
- update the flip card back face background to the requested warm gradient

## Testing
- php -l templates/checkout/order-received.php

------
https://chatgpt.com/codex/tasks/task_e_68ddea4d47288332aeb1316b4ee509d9