### PR TITLE
Use order ID as fallback tracking number for Recíbelo orders

### DIFF
--- a/assets/js/woocheck-tracking.js
+++ b/assets/js/woocheck-tracking.js
@@ -104,7 +104,9 @@ jQuery(document).ready(function($) {
         var message = data.message ? data.message : FALLBACK_MESSAGE;
 
         if (!trackingNumber && isRecibelo) {
-            setTrackingNumber($container, WAITING_COPY);
+            var fallbackTracking = ($container.data('order-id') || '').toString();
+
+            setTrackingNumber($container, fallbackTracking || WAITING_COPY);
         } else {
             setTrackingNumber($container, trackingNumber);
         }

--- a/includes/class-wc-check-shipit.php
+++ b/includes/class-wc-check-shipit.php
@@ -438,8 +438,13 @@ class WC_Check_Shipit {
         }
 
         if ( 'recibelo' === $stored_courier ) {
-            $result['tracking_number'] = '';
-            $result['message']         = __( 'Esperando tracking number...', 'woo-check' );
+            $recibelo_tracking = trim( (string) $order->get_meta( '_recibelo_internal_id', true ) );
+
+            if ( '' === $recibelo_tracking ) {
+                $recibelo_tracking = (string) $order->get_id();
+            }
+
+            $result['tracking_number'] = sanitize_text_field( $recibelo_tracking );
 
             return $result;
         }

--- a/templates/checkout/order-received.php
+++ b/templates/checkout/order-received.php
@@ -317,7 +317,6 @@ $order = wc_get_order($order_id);
                 $shipit_fallback_reference = $order_identifier !== '' ? $order_identifier . 'N' : '';
 
                 $tracking_message = __('We are checking the status of this shipment...', 'woo-check');
-                $waiting_message  = __('Esperando tracking number...', 'woo-check');
                 $tracking_number  = $generic_tracking;
 
                 $uses_recibelo_context = (
@@ -335,7 +334,7 @@ $order = wc_get_order($order_id);
                         }
 
                         if ($tracking_number === '') {
-                            $tracking_message = $waiting_message;
+                            $tracking_number = $order_identifier;
                         }
                     }
 


### PR DESCRIPTION
## Summary
- return the WooCommerce order ID as the Recíbelo tracking number when none is provided by the API
- ensure the order received page and tracking poller display the order ID instead of a waiting message for Recíbelo shipments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddee2f8d00833287ef0f18ab68220a