### PR TITLE
Improve mobile layout for order received page

### DIFF
--- a/order-received.css
+++ b/order-received.css
@@ -441,7 +441,8 @@ div#info-extra-envio {
     }
 
     .info-extra-item {
-        align-items: flex-start;
+        align-items: center;
+        gap: 2px;
         padding: 0;
     }
 
@@ -450,6 +451,10 @@ div#info-extra-envio {
         border-top: 1px solid #d9d9d9;
         padding-top: 16px;
         margin-top: 16px;
+    }
+
+    #order-thank-you-heading {
+        font-size: 28px;
     }
 }
 

--- a/templates/checkout/order-received.php
+++ b/templates/checkout/order-received.php
@@ -485,6 +485,49 @@ $order = wc_get_order($order_id);
                     }
                     window.bankTransferInfoInitialized = true;
 
+                    const setupBankTransferPositioning = function () {
+                        const bankTransferInfo = document.querySelector('.bank-transfer-info');
+                        const orderSummaryPrimary = document.querySelector('.order-summary-primary');
+                        const orderSummaryWrapper = document.querySelector('.order-summary-bank-wrapper');
+                        const orderHeader = document.querySelector('#order-header');
+
+                        if (!bankTransferInfo || !orderSummaryPrimary || !orderSummaryWrapper || !orderHeader) {
+                            return;
+                        }
+
+                        const orderAddressCard = document.querySelector('.order-address-flip-card');
+                        const mobileQuery = window.matchMedia('(max-width: 600px)');
+
+                        const repositionBankTransferInfo = function (event) {
+                            const isMobile = event && typeof event.matches === 'boolean' ? event.matches : mobileQuery.matches;
+
+                            if (isMobile) {
+                                const mobileParent = orderHeader.parentElement;
+                                const referenceNode = orderAddressCard && mobileParent && mobileParent.contains(orderAddressCard)
+                                    ? orderAddressCard
+                                    : null;
+
+                                if (referenceNode) {
+                                    if (mobileParent !== bankTransferInfo.parentElement || bankTransferInfo.nextElementSibling !== referenceNode) {
+                                        mobileParent.insertBefore(bankTransferInfo, referenceNode);
+                                    }
+                                } else if (orderHeader.nextElementSibling !== bankTransferInfo) {
+                                    orderHeader.insertAdjacentElement('afterend', bankTransferInfo);
+                                }
+                            } else if (orderSummaryWrapper !== bankTransferInfo.parentElement) {
+                                orderSummaryWrapper.appendChild(bankTransferInfo);
+                            }
+                        };
+
+                        repositionBankTransferInfo(mobileQuery);
+
+                        if (typeof mobileQuery.addEventListener === 'function') {
+                            mobileQuery.addEventListener('change', repositionBankTransferInfo);
+                        } else if (typeof mobileQuery.addListener === 'function') {
+                            mobileQuery.addListener(repositionBankTransferInfo);
+                        }
+                    };
+
                     const initBankTransferInfo = function () {
                         const toggles = document.querySelectorAll('.bank-transfer-toggle');
                         toggles.forEach(function (toggle) {
@@ -595,6 +638,8 @@ $order = wc_get_order($order_id);
                                     });
                             });
                         });
+
+                        setupBankTransferPositioning();
                     };
 
                     if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- tighten the mobile layout for the extra info tiles and heading on the order received page
- reposition the bank transfer accordion between the header and address card on small screens while keeping the desktop layout intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de65c2ba1c83329ad9ef3c5d5406d9