### PR TITLE
Revamp My Account order view layout

### DIFF
--- a/assets/css/view-order.css
+++ b/assets/css/view-order.css
@@ -1,0 +1,48 @@
+.woocommerce-order-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+.woocommerce-order-column {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.order_items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.order_item {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 1rem;
+}
+
+.order_item-thumbnail img {
+  width: 64px;
+  height: 64px;
+  object-fit: cover;
+  border-radius: 8px;
+}
+
+.order_item-quantity,
+.order_item-total {
+  font-weight: 600;
+  text-align: right;
+}
+
+.woocommerce-order-totals {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}

--- a/assets/css/view-order.css
+++ b/assets/css/view-order.css
@@ -6,9 +6,9 @@
 
 .woocommerce-order-column {
   background: #fff;
-  padding: 1.5rem;
+  /* padding: 1.5rem; */
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  /* box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1); */
 }
 
 .order_items {
@@ -86,4 +86,81 @@
 .tracking-link a:focus,
 .tracking-link a:hover {
   color: #ffffff;
+}
+
+.order-address-flip-card {
+  margin-top: 1.5rem;
+  perspective: 1000px;
+}
+
+.order-address-flip-card .flip-card {
+  position: relative;
+  width: 100%;
+  outline: none;
+  cursor: pointer;
+  border-radius: 12px;
+}
+
+.order-address-flip-card .flip-card-inner {
+  position: relative;
+  width: 100%;
+  min-height: 200px;
+  transition: transform 0.6s ease;
+  transform-style: preserve-3d;
+}
+
+.order-address-flip-card .flip-card:hover .flip-card-inner,
+.order-address-flip-card .flip-card:focus .flip-card-inner,
+.order-address-flip-card .flip-card:focus-within .flip-card-inner,
+.order-address-flip-card .flip-card.is-flipped .flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.order-address-flip-card .flip-card-face {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1.5rem;
+  backface-visibility: hidden;
+  border-radius: 12px;
+  background: #f7f7f7;
+  border: 1px solid #e3e3e3;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.order-address-flip-card .flip-card-front {
+  transform: rotateY(0deg);
+}
+
+.order-address-flip-card .flip-card-face.flip-card-back {
+  transform: rotateY(180deg);
+}
+
+.order-address-flip-card h4 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.1rem;
+}
+
+.order-address-flip-card address {
+  margin: 0;
+  font-style: normal;
+  line-height: 1.6;
+}
+
+.order-address-flip-card .flip-card a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.order-address-flip-card .flip-card:focus {
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
+}
+
+@media (max-width: 767px) {
+  .order-address-flip-card .flip-card-inner {
+    min-height: 240px;
+  }
 }

--- a/assets/css/view-order.css
+++ b/assets/css/view-order.css
@@ -80,6 +80,15 @@
   color: #ffffff;
 }
 
+.tracking-courier a {
+  color: #ffffff;
+}
+
+.tracking-courier a:focus,
+.tracking-courier a:hover {
+  color: #ffffff;
+}
+
 .order-address-flip-card {
   margin-top: 1.5rem;
   perspective: 1000px;

--- a/assets/css/view-order.css
+++ b/assets/css/view-order.css
@@ -4,6 +4,12 @@
   gap: 2rem;
 }
 
+@media (max-width: 1140px) {
+  .woocommerce-order-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
 .woocommerce-order-column {
   background: #fff;
   /* padding: 1.5rem; */

--- a/assets/css/view-order.css
+++ b/assets/css/view-order.css
@@ -46,3 +46,44 @@
   display: grid;
   gap: 0.5rem;
 }
+
+.order-header {
+  margin: 0 0 1.5rem;
+  background-image: linear-gradient(to right, #434343 0%, black 100%);
+  color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  border: 1px solid #dadada;
+}
+
+.order-header p {
+  margin: 0;
+}
+
+.order-header .fecha-hora-orden {
+  margin-top: 10px;
+  font-size: 12px;
+}
+
+.recibelo-tracking-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid #ffffff;
+  border-radius: 3px;
+  padding: 3px 6px;
+  margin-top: 10px;
+}
+
+.recibelo-tracking-status::before {
+  content: "\1F4E6";
+}
+
+.tracking-link a {
+  color: #ffffff;
+}
+
+.tracking-link a:focus,
+.tracking-link a:hover {
+  color: #ffffff;
+}

--- a/assets/css/view-order.css
+++ b/assets/css/view-order.css
@@ -39,14 +39,6 @@
   text-align: right;
 }
 
-.woocommerce-order-totals {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.5rem;
-}
-
 .order-header {
   margin: 0 0 1.5rem;
   background-image: linear-gradient(to right, #434343 0%, black 100%);

--- a/assets/css/view-order.css
+++ b/assets/css/view-order.css
@@ -85,12 +85,17 @@
   perspective: 1000px;
 }
 
-.order-address-flip-card .flip-card {
+.order-address-flip-card .flip-card { 
   position: relative;
   width: 100%;
   outline: none;
   cursor: pointer;
   border-radius: 12px;
+}
+
+.woocommerce-order-column--right > h3 {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  margin-top: 0;
 }
 
 .order-address-flip-card .flip-card-inner {

--- a/assets/css/view-order.css
+++ b/assets/css/view-order.css
@@ -133,7 +133,7 @@
   padding: 1.5rem;
   backface-visibility: hidden;
   border-radius: 12px;
-  background: #f7f7f7;
+  background: linear-gradient(314deg, rgb(255, 241, 158) 0%, rgb(220, 194, 105) 100%);
   border: 1px solid #e3e3e3;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }

--- a/assets/css/view-order.css
+++ b/assets/css/view-order.css
@@ -141,6 +141,43 @@
   margin-top: 0;
   margin-bottom: 0.75rem;
   font-size: 1.1rem;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 700;
+}
+
+#info-extra-envio {
+  margin-top: 1.5rem;
+  background: #f9f9f9;
+  border-radius: 12px;
+  border: 1px solid #e3e3e3;
+  padding: 1.25rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+.info-extra-items {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.info-extra-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.info-extra-icon {
+  font-size: 1.1rem;
+}
+
+.info-extra-label {
+  font-weight: 600;
+}
+
+.info-extra-value {
+  font-weight: 700;
+  color: #1d1d1f;
 }
 
 .order-address-flip-card address {

--- a/assets/css/view-order.css
+++ b/assets/css/view-order.css
@@ -64,7 +64,7 @@
   border: 1px solid #ffffff;
   border-radius: 3px;
   padding: 3px 6px;
-  margin-top: 10px;
+  margin: 20px 0px;
 }
 
 .recibelo-tracking-status::before {
@@ -132,10 +132,15 @@
   justify-content: center;
   padding: 1.5rem;
   backface-visibility: hidden;
-  border-radius: 12px;
+  border-radius: 8px;
   background: linear-gradient(314deg, rgb(255, 241, 158) 0%, rgb(220, 194, 105) 100%);
   border: 1px solid #e3e3e3;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.order-address-flip-card .flip-card-face.flip-card-front,
+.order-address-flip-card .flip-card-face.flip-card-back {
+  border-radius: 8px;
 }
 
 .order-address-flip-card .flip-card-front {
@@ -157,7 +162,7 @@
 #info-extra-envio {
   margin-top: 1.5rem;
   background: #f9f9f9;
-  border-radius: 12px;
+  border-radius: 8px;
   border: 1px solid #e3e3e3;
   padding: 1.25rem;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);

--- a/assets/css/view-order.css
+++ b/assets/css/view-order.css
@@ -96,12 +96,14 @@
 .woocommerce-order-column--right > h3 {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   margin-top: 0;
+  font-size: 24px;
+  font-weight: 700;
 }
 
 .order-address-flip-card .flip-card-inner {
   position: relative;
   width: 100%;
-  min-height: 200px;
+  min-height: 280px;
   transition: transform 0.6s ease;
   transform-style: preserve-3d;
 }

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -289,21 +289,6 @@ if ( '' !== $tracking_provider_label ) {
             <strong><?php esc_html_e( 'Estado del pedido:', 'woo-check' ); ?></strong> <?php echo esc_html( wc_get_order_status_name( $order->get_status() ) ); ?>
         </p>
 
-        <h3><?php esc_html_e( 'Billing Address', 'woo-check' ); ?></h3>
-        <address>
-            <?php echo wp_kses_post( $order->get_formatted_billing_address() ); ?><br>
-            <?php echo esc_html( $order->get_billing_phone() ); ?><br>
-            <?php echo esc_html( $order->get_billing_email() ); ?>
-        </address>
-
-        <h3><?php esc_html_e( 'Totals', 'woo-check' ); ?></h3>
-        <ul class="woocommerce-order-totals">
-            <li><?php esc_html_e( 'Subtotal:', 'woo-check' ); ?> <?php echo wp_kses_post( $order->get_subtotal_to_display() ); ?></li>
-            <li><?php esc_html_e( 'Shipping:', 'woo-check' ); ?> <?php echo wp_kses_post( wc_price( $order->get_shipping_total() ) ); ?></li>
-            <li><?php esc_html_e( 'Tax:', 'woo-check' ); ?> <?php echo wp_kses_post( wc_price( $order->get_total_tax() ) ); ?></li>
-            <li><strong><?php esc_html_e( 'Total:', 'woo-check' ); ?> <?php echo wp_kses_post( $order->get_formatted_order_total() ); ?></strong></li>
-        </ul>
-
         <p class="woocommerce-order-payment-method">
             <strong><?php esc_html_e( 'Payment method:', 'woo-check' ); ?></strong> <?php echo esc_html( $order->get_payment_method_title() ); ?>
         </p>

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -14,130 +14,225 @@ $order = isset( $order_id ) ? wc_get_order( $order_id ) : false;
 if ( ! $order ) {
     return;
 }
+
+$order_datetime_display = '';
+if ( $order->get_date_created() ) {
+    $order_datetime_display = $order->get_date_created()->date_i18n( 'd-m-Y H:i:s' );
+}
+
+$format_address_block = static function ( $type ) use ( $order ) {
+    $lines       = array();
+    $address_key = 'billing' === $type ? 'billing' : 'shipping';
+
+    if ( 'billing' === $address_key ) {
+        $first_name = $order->get_billing_first_name();
+        $last_name  = $order->get_billing_last_name();
+        $address_1  = $order->get_billing_address_1();
+        $address_2  = $order->get_billing_address_2();
+        $state      = $order->get_billing_state();
+        $phone      = $order->get_billing_phone();
+        $email      = $order->get_billing_email();
+    } else {
+        $first_name = $order->get_shipping_first_name();
+        $last_name  = $order->get_shipping_last_name();
+        $address_1  = $order->get_shipping_address_1();
+        $address_2  = $order->get_shipping_address_2();
+        $state      = $order->get_shipping_state();
+        $phone      = $order->get_shipping_phone();
+        $email      = '';
+    }
+
+    $comuna = '';
+
+    if ( function_exists( 'woo_check_get_order_comuna_value' ) ) {
+        $comuna = woo_check_get_order_comuna_value( $order, $address_key );
+    }
+
+    if ( '' === trim( (string) $comuna ) ) {
+        $comuna = get_post_meta( $order->get_id(), sprintf( '%s_comuna', $address_key ), true );
+    }
+
+    if ( '' === trim( (string) $comuna ) ) {
+        $comuna = 'billing' === $address_key
+            ? $order->get_billing_city()
+            : $order->get_shipping_city();
+    }
+
+    $full_name = trim( trim( (string) $first_name ) . ' ' . trim( (string) $last_name ) );
+
+    if ( '' !== $full_name ) {
+        $lines[] = esc_html( $full_name );
+    }
+
+    $address_line = trim( (string) $address_1 );
+
+    if ( '' !== trim( (string) $address_2 ) ) {
+        $address_line .= ', ' . trim( (string) $address_2 );
+    }
+
+    if ( '' !== $address_line ) {
+        $lines[] = esc_html( $address_line );
+    }
+
+    if ( '' !== trim( (string) $comuna ) ) {
+        $lines[] = esc_html( (string) $comuna );
+    }
+
+    if ( '' !== trim( (string) $state ) ) {
+        $lines[] = esc_html( (string) $state );
+    }
+
+    if ( '' !== trim( (string) $phone ) ) {
+        $lines[] = wc_make_phone_clickable( $phone );
+    }
+
+    if ( '' !== trim( (string) $email ) ) {
+        $lines[] = sprintf(
+            '<a href="mailto:%1$s">%2$s</a>',
+            esc_attr( $email ),
+            esc_html( $email )
+        );
+    }
+
+    $lines = array_filter(
+        $lines,
+        static function ( $line ) {
+            return '' !== $line && null !== $line;
+        }
+    );
+
+    return implode( '<br>', $lines );
+};
+
+$billing_address_content  = $format_address_block( 'billing' );
+$shipping_address_content = $format_address_block( 'shipping' );
+
+if ( empty( $billing_address_content ) && ! empty( $shipping_address_content ) ) {
+    $billing_address_content = $shipping_address_content;
+}
+
+if ( empty( $shipping_address_content ) && ! empty( $billing_address_content ) ) {
+    $shipping_address_content = $billing_address_content;
+}
+
+$has_address_information = ! empty( $billing_address_content ) || ! empty( $shipping_address_content );
+
+$tracking_provider_raw = get_post_meta( $order->get_id(), '_tracking_provider', true );
+
+$tracking_provider_labels = array(
+    'recibelo' => __( 'Recíbelo', 'woo-check' ),
+    'shipit'   => __( 'Shipit', 'woo-check' ),
+);
+
+$tracking_provider_slug  = '';
+$tracking_provider_label = '';
+
+if ( is_string( $tracking_provider_raw ) ) {
+    $tracking_provider_candidate = strtolower( trim( $tracking_provider_raw ) );
+
+    if ( isset( $tracking_provider_labels[ $tracking_provider_candidate ] ) ) {
+        $tracking_provider_slug  = $tracking_provider_candidate;
+        $tracking_provider_label = $tracking_provider_labels[ $tracking_provider_candidate ];
+    }
+}
+
+$recibelo_internal_id = trim( (string) get_post_meta( $order->get_id(), '_recibelo_internal_id', true ) );
+$shipit_tracking      = trim( (string) get_post_meta( $order->get_id(), '_shipit_tracking', true ) );
+$generic_tracking     = trim( (string) get_post_meta( $order->get_id(), '_tracking_number', true ) );
+
+$order_targets_recibelo = function_exists( 'wc_check_order_targets_recibelo' )
+    ? wc_check_order_targets_recibelo( $order )
+    : false;
+
+$order_identifier          = (string) $order->get_id();
+$shipit_fallback_reference = '' !== $order_identifier ? $order_identifier . 'N' : '';
+
+$tracking_message = __( 'We are checking the status of this shipment...', 'woo-check' );
+$tracking_number  = $generic_tracking;
+$default_tracking = $tracking_number;
+
+$uses_recibelo_context = (
+    'recibelo' === $tracking_provider_slug
+    || $order_targets_recibelo
+    || '' !== $recibelo_internal_id
+);
+
+if ( $uses_recibelo_context ) {
+    if ( '' !== $recibelo_internal_id ) {
+        $tracking_number = $recibelo_internal_id;
+    } else {
+        if ( $tracking_number === $shipit_fallback_reference ) {
+            $tracking_number = '';
+        }
+
+        if ( '' === $tracking_number ) {
+            $tracking_number = $order_identifier;
+        }
+    }
+
+    if ( 'recibelo' !== $tracking_provider_slug ) {
+        $tracking_provider_slug  = 'recibelo';
+        $tracking_provider_label = $tracking_provider_labels['recibelo'];
+    }
+} else {
+    if ( '' === $tracking_number ) {
+        if ( '' !== $shipit_tracking ) {
+            $tracking_number = $shipit_tracking;
+        } elseif ( 'shipit' === $tracking_provider_slug && '' !== $shipit_fallback_reference ) {
+            $tracking_number = $shipit_fallback_reference;
+        }
+    }
+}
+
+if ( '' !== $tracking_number ) {
+    $tracking_number_display = $tracking_number;
+} elseif ( '' !== $tracking_provider_label ) {
+    $tracking_number_display = $tracking_message;
+} else {
+    $tracking_number_display = '';
+}
+
+$tracking_message_visible = ( '' === $tracking_number && '' === $tracking_provider_label );
+$tracking_message_style   = $tracking_message_visible ? '' : ' style="display:none;"';
+
+$tracking_courier_html = '';
+
+if ( '' !== $tracking_provider_label ) {
+    if ( 'recibelo' === $tracking_provider_slug ) {
+        $tracking_courier_html = sprintf(
+            '(<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>)',
+            esc_url( 'https://recibelo.cl/seguimiento' ),
+            esc_html( $tracking_provider_label )
+        );
+    } else {
+        $tracking_courier_html = sprintf( '(%s)', esc_html( $tracking_provider_label ) );
+    }
+}
+
+$tracking_status_attributes = sprintf(
+    'data-order-id="%s"',
+    esc_attr( $order->get_id() )
+);
+
+if ( '' !== $tracking_provider_slug ) {
+    $tracking_status_attributes .= sprintf(
+        ' data-tracking-provider="%s"',
+        esc_attr( $tracking_provider_slug )
+    );
+}
+
+if ( '' !== $tracking_provider_label ) {
+    $tracking_status_attributes .= sprintf(
+        ' data-tracking-provider-label="%s"',
+        esc_attr( $tracking_provider_label )
+    );
+}
 ?>
 
 <div class="woocommerce-order-columns">
 
     <!-- Left Column -->
     <div class="woocommerce-order-column woocommerce-order-column--left">
-        <?php
-        $order_datetime_display = '';
-
-        if ( $order->get_date_created() ) {
-            $order_datetime_display = $order->get_date_created()->date_i18n( 'd-m-Y H:i:s' );
-        }
-
-        $tracking_provider_raw = get_post_meta( $order->get_id(), '_tracking_provider', true );
-
-        $tracking_provider_labels = array(
-            'recibelo' => __( 'Recíbelo', 'woo-check' ),
-            'shipit'   => __( 'Shipit', 'woo-check' ),
-        );
-
-        $tracking_provider_slug  = '';
-        $tracking_provider_label = '';
-
-        if ( is_string( $tracking_provider_raw ) ) {
-            $tracking_provider_candidate = strtolower( trim( $tracking_provider_raw ) );
-
-            if ( isset( $tracking_provider_labels[ $tracking_provider_candidate ] ) ) {
-                $tracking_provider_slug  = $tracking_provider_candidate;
-                $tracking_provider_label = $tracking_provider_labels[ $tracking_provider_candidate ];
-            }
-        }
-
-        $recibelo_internal_id = trim( (string) get_post_meta( $order->get_id(), '_recibelo_internal_id', true ) );
-        $shipit_tracking      = trim( (string) get_post_meta( $order->get_id(), '_shipit_tracking', true ) );
-        $generic_tracking     = trim( (string) get_post_meta( $order->get_id(), '_tracking_number', true ) );
-
-        $order_targets_recibelo = function_exists( 'wc_check_order_targets_recibelo' )
-            ? wc_check_order_targets_recibelo( $order )
-            : false;
-
-        $order_identifier          = (string) $order->get_id();
-        $shipit_fallback_reference = '' !== $order_identifier ? $order_identifier . 'N' : '';
-
-        $tracking_message = __( 'We are checking the status of this shipment...', 'woo-check' );
-        $tracking_number  = $generic_tracking;
-        $default_tracking = $tracking_number;
-
-        $uses_recibelo_context = (
-            'recibelo' === $tracking_provider_slug
-            || $order_targets_recibelo
-            || '' !== $recibelo_internal_id
-        );
-
-        if ( $uses_recibelo_context ) {
-            if ( '' !== $recibelo_internal_id ) {
-                $tracking_number = $recibelo_internal_id;
-            } else {
-                if ( $tracking_number === $shipit_fallback_reference ) {
-                    $tracking_number = '';
-                }
-
-                if ( '' === $tracking_number ) {
-                    $tracking_number = $order_identifier;
-                }
-            }
-
-            if ( 'recibelo' !== $tracking_provider_slug ) {
-                $tracking_provider_slug  = 'recibelo';
-                $tracking_provider_label = $tracking_provider_labels['recibelo'];
-            }
-        } else {
-            if ( '' === $tracking_number ) {
-                if ( '' !== $shipit_tracking ) {
-                    $tracking_number = $shipit_tracking;
-                } elseif ( 'shipit' === $tracking_provider_slug && '' !== $shipit_fallback_reference ) {
-                    $tracking_number = $shipit_fallback_reference;
-                }
-            }
-        }
-
-        if ( '' !== $tracking_number ) {
-            $tracking_number_display = $tracking_number;
-        } elseif ( '' !== $tracking_provider_label ) {
-            $tracking_number_display = $tracking_message;
-        } else {
-            $tracking_number_display = '';
-        }
-
-        $tracking_message_visible = ( '' === $tracking_number && '' === $tracking_provider_label );
-        $tracking_message_style   = $tracking_message_visible ? '' : ' style="display:none;"';
-
-        $tracking_courier_html = '';
-
-        if ( '' !== $tracking_provider_label ) {
-            if ( 'recibelo' === $tracking_provider_slug ) {
-                $tracking_courier_html = sprintf(
-                    '(<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>)',
-                    esc_url( 'https://recibelo.cl/seguimiento' ),
-                    esc_html( $tracking_provider_label )
-                );
-            } else {
-                $tracking_courier_html = sprintf( '(%s)', esc_html( $tracking_provider_label ) );
-            }
-        }
-
-        $tracking_status_attributes = sprintf(
-            'data-order-id="%s"',
-            esc_attr( $order->get_id() )
-        );
-
-        if ( '' !== $tracking_provider_slug ) {
-            $tracking_status_attributes .= sprintf(
-                ' data-tracking-provider="%s"',
-                esc_attr( $tracking_provider_slug )
-            );
-        }
-
-        if ( '' !== $tracking_provider_label ) {
-            $tracking_status_attributes .= sprintf(
-                ' data-tracking-provider-label="%s"',
-                esc_attr( $tracking_provider_label )
-            );
-        }
-        ?>
         <div id="order-header" class="order-header">
             <p class="titulo-seccion">
                 <?php esc_html_e( 'Número de orden:', 'woo-check' ); ?> <?php echo esc_html( $order->get_id() ); ?>
@@ -172,6 +267,23 @@ if ( ! $order ) {
                 <p class="fecha-hora-orden"><?php printf( esc_html__( 'Fecha y hora de la orden: %s', 'woo-check' ), esc_html( $order_datetime_display ) ); ?></p>
             <?php endif; ?>
         </div>
+
+        <?php if ( $has_address_information ) : ?>
+            <div class="order-address-flip-card">
+                <div class="flip-card" tabindex="0" role="button" aria-label="<?php esc_attr_e( 'Ver direcciones de facturación y envío', 'woocommerce' ); ?>" aria-pressed="false">
+                    <div class="flip-card-inner">
+                        <div class="flip-card-face flip-card-front">
+                            <h4><?php esc_html_e( 'Dirección de Facturación', 'woocommerce' ); ?></h4>
+                            <address><?php echo wp_kses_post( $billing_address_content ); ?></address>
+                        </div>
+                        <div class="flip-card-face flip-card-back">
+                            <h4><?php esc_html_e( 'Dirección de Envío', 'woocommerce' ); ?></h4>
+                            <address><?php echo wp_kses_post( $shipping_address_content ); ?></address>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        <?php endif; ?>
 
         <p class="woocommerce-order-status">
             <strong><?php esc_html_e( 'Estado del pedido:', 'woo-check' ); ?></strong> <?php echo esc_html( wc_get_order_status_name( $order->get_status() ) ); ?>
@@ -217,3 +329,42 @@ if ( ! $order ) {
     </div>
 
 </div>
+
+<?php if ( $has_address_information ) : ?>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        var flipCard = document.querySelector('.order-address-flip-card .flip-card');
+        if (!flipCard) {
+            return;
+        }
+
+        var supportsHover = window.matchMedia('(hover: hover)').matches;
+
+        var updatePressedState = function() {
+            flipCard.setAttribute('aria-pressed', flipCard.classList.contains('is-flipped') ? 'true' : 'false');
+        };
+
+        updatePressedState();
+
+        if (!supportsHover) {
+            flipCard.addEventListener('click', function(event) {
+                if (event.target.closest('a')) {
+                    return;
+                }
+
+                event.preventDefault();
+                flipCard.classList.toggle('is-flipped');
+                updatePressedState();
+            });
+        }
+
+        flipCard.addEventListener('keydown', function(event) {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                flipCard.classList.toggle('is-flipped');
+                updatePressedState();
+            }
+        });
+    });
+    </script>
+<?php endif; ?>

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -321,6 +321,30 @@ if ( '' !== $tracking_provider_label ) {
         if ( '' !== $tax_rate_percent ) {
             $tax_total_label = sprintf( '%s (%s%%)', $tax_total_label_base, $tax_rate_percent );
         }
+
+        $payment_method_title = wp_strip_all_tags( (string) $order->get_payment_method_title() );
+        $payment_method_emoji = '';
+
+        if ( '' !== $payment_method_title ) {
+            $normalized_payment_title = $payment_method_title;
+
+            if ( function_exists( 'remove_accents' ) ) {
+                $normalized_payment_title = remove_accents( $normalized_payment_title );
+            }
+
+            $normalized_payment_title = strtolower( $normalized_payment_title );
+
+            if ( false !== strpos( $normalized_payment_title, 'transferencia' ) ) {
+                $payment_method_emoji = '🏦';
+            } elseif (
+                false !== strpos( $normalized_payment_title, 'debito' )
+                || false !== strpos( $normalized_payment_title, 'credito' )
+            ) {
+                $payment_method_emoji = '💳';
+            } else {
+                $payment_method_emoji = '💳';
+            }
+        }
         ?>
 
         <?php if ( $has_address_information ) : ?>
@@ -360,9 +384,15 @@ if ( '' !== $tracking_provider_label ) {
             </div>
         </div>
 
-        <p class="woocommerce-order-payment-method">
-            <strong><?php esc_html_e( 'Payment method:', 'woo-check' ); ?></strong> <?php echo esc_html( $order->get_payment_method_title() ); ?>
-        </p>
+        <?php if ( '' !== $payment_method_title ) : ?>
+            <p class="woocommerce-order-payment-method">
+                <?php if ( '' !== $payment_method_emoji ) : ?>
+                    <span class="payment-method-emoji" aria-hidden="true"><?php echo esc_html( $payment_method_emoji ); ?></span>
+                <?php endif; ?>
+                <span class="screen-reader-text"><?php esc_html_e( 'Payment method:', 'woo-check' ); ?></span>
+                <span class="payment-method-value"><?php echo esc_html( $payment_method_title ); ?></span>
+            </p>
+        <?php endif; ?>
     </div>
 
     <!-- Right Column -->

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -285,10 +285,6 @@ if ( '' !== $tracking_provider_label ) {
             </div>
         <?php endif; ?>
 
-        <p class="woocommerce-order-status">
-            <strong><?php esc_html_e( 'Estado del pedido:', 'woo-check' ); ?></strong> <?php echo esc_html( wc_get_order_status_name( $order->get_status() ) ); ?>
-        </p>
-
         <p class="woocommerce-order-payment-method">
             <strong><?php esc_html_e( 'Payment method:', 'woo-check' ); ?></strong> <?php echo esc_html( $order->get_payment_method_title() ); ?>
         </p>
@@ -296,7 +292,7 @@ if ( '' !== $tracking_provider_label ) {
 
     <!-- Right Column -->
     <div class="woocommerce-order-column woocommerce-order-column--right">
-        <h3><?php esc_html_e( 'Your Items', 'woo-check' ); ?></h3>
+        <h3><?php esc_html_e( 'Tu compra', 'woo-check' ); ?></h3>
         <ul class="order_items">
             <?php foreach ( $order->get_items() as $item_id => $item ) : ?>
                 <?php

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -41,6 +41,10 @@ if ( ! $order ) {
             <li><?php esc_html_e( 'Tax:', 'woo-check' ); ?> <?php echo wp_kses_post( wc_price( $order->get_total_tax() ) ); ?></li>
             <li><strong><?php esc_html_e( 'Total:', 'woo-check' ); ?> <?php echo wp_kses_post( $order->get_formatted_order_total() ); ?></strong></li>
         </ul>
+
+        <p class="woocommerce-order-payment-method">
+            <strong><?php esc_html_e( 'Payment method:', 'woo-check' ); ?></strong> <?php echo esc_html( $order->get_payment_method_title() ); ?>
+        </p>
     </div>
 
     <!-- Right Column -->
@@ -63,4 +67,3 @@ if ( ! $order ) {
     </div>
 
 </div>
-<?php do_action( 'woocommerce_view_order', $order->get_id() ); ?>

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -268,6 +268,42 @@ if ( '' !== $tracking_provider_label ) {
             <?php endif; ?>
         </div>
 
+        <?php
+        $tax_totals      = $order->get_tax_totals();
+        $tax_total_label = __( 'IVA', 'woo-check' );
+
+        if ( ! empty( $tax_totals ) ) {
+            $first_tax_total = reset( $tax_totals );
+
+            if ( is_object( $first_tax_total ) ) {
+                if ( method_exists( $first_tax_total, 'get_label' ) ) {
+                    $tax_total_label = $first_tax_total->get_label();
+                } elseif ( isset( $first_tax_total->label ) && '' !== $first_tax_total->label ) {
+                    $tax_total_label = $first_tax_total->label;
+                }
+
+                $rate_percent = '';
+                if ( method_exists( $first_tax_total, 'get_rate_percent' ) ) {
+                    $rate_percent = $first_tax_total->get_rate_percent();
+                } elseif ( isset( $first_tax_total->rate_percent ) ) {
+                    $rate_percent = $first_tax_total->rate_percent;
+                }
+
+                if ( '' !== $rate_percent && ! is_wp_error( $rate_percent ) ) {
+                    $rate_percent = wc_trim_zeros( wc_format_decimal( $rate_percent, 2 ) );
+
+                    if ( 0 === (float) $rate_percent || '' === $rate_percent ) {
+                        $rate_percent = '';
+                    }
+                }
+
+                if ( '' !== $rate_percent ) {
+                    $tax_total_label = sprintf( '%s (%s%%)', $tax_total_label, $rate_percent );
+                }
+            }
+        }
+        ?>
+
         <?php if ( $has_address_information ) : ?>
             <div class="order-address-flip-card">
                 <div id="order-address-flip-card" class="flip-card" tabindex="0" role="button" aria-label="<?php esc_attr_e( 'Ver direcciones de facturación y envío', 'woocommerce' ); ?>" aria-pressed="false">
@@ -284,6 +320,26 @@ if ( '' !== $tracking_provider_label ) {
                 </div>
             </div>
         <?php endif; ?>
+
+        <div id="info-extra-envio">
+            <div class="info-extra-items" role="list">
+                <div class="info-extra-item" role="listitem">
+                    <span class="info-extra-icon" aria-hidden="true">🚚</span>
+                    <span class="info-extra-label"><?php esc_html_e( 'Envío', 'woo-check' ); ?></span>
+                    <span class="info-extra-value"><?php echo wp_kses_post( wc_price( (float) $order->get_shipping_total() + (float) $order->get_shipping_tax() ) ); ?></span>
+                </div>
+                <div class="info-extra-item" role="listitem">
+                    <span class="info-extra-icon" aria-hidden="true">🕵️‍♂️</span>
+                    <span class="info-extra-label"><?php echo esc_html( $tax_total_label ); ?></span>
+                    <span class="info-extra-value"><?php echo wp_kses_post( wc_price( (float) $order->get_total_tax() ) ); ?></span>
+                </div>
+                <div class="info-extra-item" role="listitem">
+                    <span class="info-extra-icon" aria-hidden="true">💵</span>
+                    <span class="info-extra-label"><?php esc_html_e( 'Total Orden', 'woo-check' ); ?></span>
+                    <span class="info-extra-value"><?php echo wp_kses_post( $order->get_formatted_order_total() ); ?></span>
+                </div>
+            </div>
+        </div>
 
         <p class="woocommerce-order-payment-method">
             <strong><?php esc_html_e( 'Payment method:', 'woo-check' ); ?></strong> <?php echo esc_html( $order->get_payment_method_title() ); ?>

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -20,12 +20,162 @@ if ( ! $order ) {
 
     <!-- Left Column -->
     <div class="woocommerce-order-column woocommerce-order-column--left">
-        <h2><?php printf( __( 'Order #%s', 'woo-check' ), esc_html( $order->get_order_number() ) ); ?></h2>
-        <p><?php echo esc_html( wc_format_datetime( $order->get_date_created() ) ); ?></p>
-        <p><?php echo esc_html( wc_get_order_status_name( $order->get_status() ) ); ?></p>
+        <?php
+        $order_datetime_display = '';
 
-        <!-- Tracking (if handled by woo-check) -->
-        <?php do_action( 'woo_check_order_tracking', $order ); ?>
+        if ( $order->get_date_created() ) {
+            $order_datetime_display = $order->get_date_created()->date_i18n( 'd-m-Y H:i:s' );
+        }
+
+        $tracking_provider_raw = get_post_meta( $order->get_id(), '_tracking_provider', true );
+
+        $tracking_provider_labels = array(
+            'recibelo' => __( 'Recíbelo', 'woo-check' ),
+            'shipit'   => __( 'Shipit', 'woo-check' ),
+        );
+
+        $tracking_provider_slug  = '';
+        $tracking_provider_label = '';
+
+        if ( is_string( $tracking_provider_raw ) ) {
+            $tracking_provider_candidate = strtolower( trim( $tracking_provider_raw ) );
+
+            if ( isset( $tracking_provider_labels[ $tracking_provider_candidate ] ) ) {
+                $tracking_provider_slug  = $tracking_provider_candidate;
+                $tracking_provider_label = $tracking_provider_labels[ $tracking_provider_candidate ];
+            }
+        }
+
+        $recibelo_internal_id = trim( (string) get_post_meta( $order->get_id(), '_recibelo_internal_id', true ) );
+        $shipit_tracking      = trim( (string) get_post_meta( $order->get_id(), '_shipit_tracking', true ) );
+        $generic_tracking     = trim( (string) get_post_meta( $order->get_id(), '_tracking_number', true ) );
+
+        $order_targets_recibelo = function_exists( 'wc_check_order_targets_recibelo' )
+            ? wc_check_order_targets_recibelo( $order )
+            : false;
+
+        $order_identifier          = (string) $order->get_id();
+        $shipit_fallback_reference = '' !== $order_identifier ? $order_identifier . 'N' : '';
+
+        $tracking_message = __( 'We are checking the status of this shipment...', 'woo-check' );
+        $tracking_number  = $generic_tracking;
+        $default_tracking = $tracking_number;
+
+        $uses_recibelo_context = (
+            'recibelo' === $tracking_provider_slug
+            || $order_targets_recibelo
+            || '' !== $recibelo_internal_id
+        );
+
+        if ( $uses_recibelo_context ) {
+            if ( '' !== $recibelo_internal_id ) {
+                $tracking_number = $recibelo_internal_id;
+            } else {
+                if ( $tracking_number === $shipit_fallback_reference ) {
+                    $tracking_number = '';
+                }
+
+                if ( '' === $tracking_number ) {
+                    $tracking_number = $order_identifier;
+                }
+            }
+
+            if ( 'recibelo' !== $tracking_provider_slug ) {
+                $tracking_provider_slug  = 'recibelo';
+                $tracking_provider_label = $tracking_provider_labels['recibelo'];
+            }
+        } else {
+            if ( '' === $tracking_number ) {
+                if ( '' !== $shipit_tracking ) {
+                    $tracking_number = $shipit_tracking;
+                } elseif ( 'shipit' === $tracking_provider_slug && '' !== $shipit_fallback_reference ) {
+                    $tracking_number = $shipit_fallback_reference;
+                }
+            }
+        }
+
+        if ( '' !== $tracking_number ) {
+            $tracking_number_display = $tracking_number;
+        } elseif ( '' !== $tracking_provider_label ) {
+            $tracking_number_display = $tracking_message;
+        } else {
+            $tracking_number_display = '';
+        }
+
+        $tracking_message_visible = ( '' === $tracking_number && '' === $tracking_provider_label );
+        $tracking_message_style   = $tracking_message_visible ? '' : ' style="display:none;"';
+
+        $tracking_courier_html = '';
+
+        if ( '' !== $tracking_provider_label ) {
+            if ( 'recibelo' === $tracking_provider_slug ) {
+                $tracking_courier_html = sprintf(
+                    '(<a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>)',
+                    esc_url( 'https://recibelo.cl/seguimiento' ),
+                    esc_html( $tracking_provider_label )
+                );
+            } else {
+                $tracking_courier_html = sprintf( '(%s)', esc_html( $tracking_provider_label ) );
+            }
+        }
+
+        $tracking_status_attributes = sprintf(
+            'data-order-id="%s"',
+            esc_attr( $order->get_id() )
+        );
+
+        if ( '' !== $tracking_provider_slug ) {
+            $tracking_status_attributes .= sprintf(
+                ' data-tracking-provider="%s"',
+                esc_attr( $tracking_provider_slug )
+            );
+        }
+
+        if ( '' !== $tracking_provider_label ) {
+            $tracking_status_attributes .= sprintf(
+                ' data-tracking-provider-label="%s"',
+                esc_attr( $tracking_provider_label )
+            );
+        }
+        ?>
+        <div id="order-header" class="order-header">
+            <p class="titulo-seccion">
+                <?php esc_html_e( 'Número de orden:', 'woo-check' ); ?> <?php echo esc_html( $order->get_id() ); ?>
+            </p>
+            <div id="tracking-status" <?php echo $tracking_status_attributes; ?>>
+                <p class="tracking-heading">
+                    <strong><?php esc_html_e( 'Tracking:', 'woo-check' ); ?></strong>
+                    <span class="tracking-number"><?php echo esc_html( $tracking_number_display ); ?></span>
+                    <?php if ( '' !== $tracking_courier_html ) : ?>
+                        <span class="tracking-courier"><?php echo wp_kses_post( $tracking_courier_html ); ?></span>
+                    <?php endif; ?>
+                </p>
+                <p class="tracking-message"<?php echo $tracking_message_style; ?>><?php echo esc_html( $tracking_message ); ?></p>
+                <p class="tracking-link" style="display:none;"><a href="#" target="_blank" rel="noopener noreferrer"></a></p>
+            </div>
+            <?php if ( 'recibelo' === $tracking_provider_slug ) : ?>
+                <?php
+                $internal_id = get_post_meta( $order->get_id(), '_recibelo_internal_id', true );
+
+                if ( empty( $internal_id ) ) {
+                    $internal_id = $default_tracking;
+                }
+
+                $billing_full_name = $order->get_formatted_billing_full_name();
+                $tracking_status   = class_exists( 'WC_Check_Recibelo' )
+                    ? WC_Check_Recibelo::get_tracking_status( $internal_id, $billing_full_name )
+                    : __( 'Estamos consultando el estado de este envío...', 'woo-check' );
+                ?>
+                <p class="recibelo-tracking-status"><?php echo esc_html( $tracking_status ); ?></p>
+            <?php endif; ?>
+            <?php if ( '' !== $order_datetime_display ) : ?>
+                <p class="fecha-hora-orden"><?php printf( esc_html__( 'Fecha y hora de la orden: %s', 'woo-check' ), esc_html( $order_datetime_display ) ); ?></p>
+            <?php endif; ?>
+        </div>
+
+        <p class="woocommerce-order-status">
+            <strong><?php esc_html_e( 'Estado del pedido:', 'woo-check' ); ?></strong> <?php echo esc_html( wc_get_order_status_name( $order->get_status() ) ); ?>
+        </p>
 
         <h3><?php esc_html_e( 'Billing Address', 'woo-check' ); ?></h3>
         <address>

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -270,7 +270,7 @@ if ( '' !== $tracking_provider_label ) {
 
         <?php if ( $has_address_information ) : ?>
             <div class="order-address-flip-card">
-                <div class="flip-card" tabindex="0" role="button" aria-label="<?php esc_attr_e( 'Ver direcciones de facturación y envío', 'woocommerce' ); ?>" aria-pressed="false">
+                <div id="order-address-flip-card" class="flip-card" tabindex="0" role="button" aria-label="<?php esc_attr_e( 'Ver direcciones de facturación y envío', 'woocommerce' ); ?>" aria-pressed="false">
                     <div class="flip-card-inner">
                         <div class="flip-card-face flip-card-front">
                             <h4><?php esc_html_e( 'Dirección de Facturación', 'woocommerce' ); ?></h4>
@@ -318,7 +318,7 @@ if ( '' !== $tracking_provider_label ) {
 <?php if ( $has_address_information ) : ?>
     <script>
     document.addEventListener('DOMContentLoaded', function() {
-        var flipCard = document.querySelector('.order-address-flip-card .flip-card');
+        var flipCard = document.getElementById('order-address-flip-card');
         if (!flipCard) {
             return;
         }

--- a/woo-check.php
+++ b/woo-check.php
@@ -961,6 +961,15 @@ function woo_check_enqueue_assets() {
         '1.0'
     );
 
+    if ( function_exists( 'is_account_page' ) && is_account_page() ) {
+        wp_enqueue_style(
+            'woo-check-view-order',
+            plugin_dir_url(__FILE__) . 'assets/css/view-order.css',
+            array(),
+            '1.0.0'
+        );
+    }
+
     $is_checkout     = function_exists('is_checkout') ? is_checkout() : false;
     $is_edit_address = function_exists('is_wc_endpoint_url') ? is_wc_endpoint_url('edit-address') : false;
 


### PR DESCRIPTION
## Summary
- replace the My Account order view template with a two-column layout matching the order received page styling
- add dedicated view-order stylesheet to support the new layout presentation
- enqueue the view-order stylesheet on My Account pages

## Testing
- php -l templates/myaccount/view-order.php
- php -l woo-check.php

------
https://chatgpt.com/codex/tasks/task_e_68de8a5f8ffc8332a2c8eadda1b0e69f