### PR TITLE
Fix region syncing and checkout updates for commune selection

### DIFF
--- a/woo-check-autocomplete.js
+++ b/woo-check-autocomplete.js
@@ -1,68 +1,54 @@
 // woo-check-autocomplete.js
 
-jQuery(document).ready(function ($) {
+console.log("✅ WooCheck JS file LOADED at top of script");
 
-    // Función para normalizar cadenas
-    function normalizeString(str) {
-        return str
-            .trim() // Elimina espacios al inicio y al final
-            .normalize('NFD') // Divide letras y acentos
-            .replace(/[\u0300-\u036f]/g, '') // Elimina los acentos
-            .replace(/[’']/g, '') // Elimina apóstrofes
-            .replace(/[^a-zA-ZñÑ0-9\s]/g, '') // Retiene "ñ" y "Ñ"
-            .toLowerCase() // Convierte a minúsculas
-            .replace(/\s+/g, ' '); // Normaliza los espacios intermedios
+jQuery(document).ready(function ($) {
+    console.log("✅ jQuery(document).ready() is running");
+    console.log("jQuery version:", $.fn.jquery);
+    console.log("billing_city exists?", $('#billing_city').length > 0);
+
+    // --- SAFETY CHECK FOR comunasChile ---
+    if (typeof comunasChile === "undefined") {
+        console.error("❌ comunasChile is NOT defined. Autocomplete cannot run.");
+        return;
+    } else {
+        console.log("✅ comunasChile is loaded, proceeding with autocomplete.");
     }
 
-    // Crear el mapa comuna -> región utilizando la normalización
+    // --- NORMALIZATION FUNCTION ---
+    function normalizeString(str) {
+        return str
+            .trim()
+            .normalize('NFD')
+            .replace(/[\u0300-\u036f]/g, '')
+            .replace(/[’']/g, '')
+            .replace(/[^a-zA-ZñÑ0-9\s]/g, '')
+            .toLowerCase()
+            .replace(/\s+/g, ' ');
+    }
+
+    // --- CREATE COMUNA → REGION MAPS ---
     const comunaToRegionMap = {};
-    const regionCodeMap = {
-        'arica y parinacota': 'CL-AP',
-        'tarapaca': 'CL-TA',
-        'antofagasta': 'CL-AN',
-        'atacama': 'CL-AT',
-        'coquimbo': 'CL-CO',
-        'valparaiso': 'CL-VS',
-        'metropolitana de santiago': 'CL-RM',
-        'region metropolitana': 'CL-RM',
-        'libertador general bernardo ohiggins': 'CL-LI',
-        'maule': 'CL-ML',
-        'nuble': 'CL-NB',
-        'biobio': 'CL-BI',
-        'araucania': 'CL-AR',
-        'los rios': 'CL-LR',
-        'los lagos': 'CL-LL',
-        'aysen': 'CL-AI',
-        'magallanes': 'CL-MA'
-    };
-    const comunaExactMap = {}; // Mapa para obtener el nombre exacto de la comuna
+    const comunaExactMap = {};
     comunasChile.forEach(entry => {
         entry.comunas.forEach(comuna => {
-            const normalizedComuna = normalizeString(comuna);
-            comunaToRegionMap[normalizedComuna] = entry.region; // Mapear al nombre de la región
-            comunaExactMap[normalizedComuna] = comuna; // Almacena el nombre exacto
+            const normalized = normalizeString(comuna);
+            comunaToRegionMap[normalized] = entry.region;
+            comunaExactMap[normalized] = comuna;
         });
     });
 
-    // Crear la lista de comunas originales para el autocompletado
+    // --- CREATE FULL COMUNA LIST ---
     const comunaList = [];
     comunasChile.forEach(entry => {
-        entry.comunas.forEach(comuna => {
-            comunaList.push(comuna);
-        });
+        entry.comunas.forEach(comuna => comunaList.push(comuna));
     });
 
-    // Calcular la distancia de Levenshtein entre dos cadenas
+    // --- LEVENSHTEIN DISTANCE FUNCTION ---
     function levenshteinDistance(a, b) {
         const matrix = [];
-
-        for (let i = 0; i <= b.length; i++) {
-            matrix[i] = [i];
-        }
-
-        for (let j = 0; j <= a.length; j++) {
-            matrix[0][j] = j;
-        }
+        for (let i = 0; i <= b.length; i++) matrix[i] = [i];
+        for (let j = 0; j <= a.length; j++) matrix[0][j] = j;
 
         for (let i = 1; i <= b.length; i++) {
             for (let j = 1; j <= a.length; j++) {
@@ -77,19 +63,15 @@ jQuery(document).ready(function ($) {
                 }
             }
         }
-
         return matrix[b.length][a.length];
     }
 
-    // Buscar la comuna más parecida a un valor ingresado
+    // --- FIND CLOSEST MATCH ---
     function findClosestComuna(value) {
         const normalizedValue = normalizeString(value);
+        if (!normalizedValue) return null;
 
-        if (!normalizedValue) {
-            return null;
-        }
-
-        let closestComuna = null;
+        let closest = null;
         let bestScore = 0;
 
         comunaList.forEach(comuna => {
@@ -100,257 +82,92 @@ jQuery(document).ready(function ($) {
 
             if (similarity > bestScore) {
                 bestScore = similarity;
-                closestComuna = comuna;
+                closest = comuna;
             }
         });
 
-        return bestScore >= 0.6 ? closestComuna : null;
+        return bestScore >= 0.6 ? closest : null;
     }
 
-    function getSuggestionContainer(comunaInput) {
-        let container = comunaInput.siblings('.woo-check-comuna-suggestion');
-
-        if (!container.length) {
-            container = $('<div>', {
-                class: 'woo-check-comuna-suggestion',
-            });
-            comunaInput.after(container);
-        }
-
-        return container;
-    }
-
-    function clearComunaSuggestion(comunaInput) {
-        comunaInput.removeClass('woo-check-comuna-input--invalid');
-        const container = comunaInput.siblings('.woo-check-comuna-suggestion');
-        if (container.length) {
-            container.empty().removeClass('woo-check-comuna-suggestion--visible');
-        }
-    }
-
-    function showComunaSuggestion(comunaInput, suggestion, regionSelect) {
-        const container = getSuggestionContainer(comunaInput);
-        container.empty();
-
-        if (!suggestion) {
-            comunaInput.addClass('woo-check-comuna-input--invalid');
-            container
-                .removeClass('woo-check-comuna-suggestion--has-option')
-                .addClass('woo-check-comuna-suggestion--visible')
-                .text('No encontramos una coincidencia para la comuna ingresada.');
-            return;
-        }
-
-        comunaInput.addClass('woo-check-comuna-input--invalid');
-        container
-            .addClass('woo-check-comuna-suggestion--visible woo-check-comuna-suggestion--has-option')
-            .append($('<span>').text('¿Quisiste decir '));
-
-        const suggestionRegion = comunaToRegionMap[normalizeString(suggestion)];
-
-        const suggestionButton = $('<button>', {
-            type: 'button',
-            class: 'woo-check-comuna-suggestion__button',
-            text: suggestion,
-        });
-
-        suggestionButton.on('click', function () {
-            comunaInput.val(suggestion);
-            clearComunaSuggestion(comunaInput);
-            syncRegionWithComuna(comunaInput, regionSelect);
-        });
-
-        container.append(suggestionButton);
-
-        if (suggestionRegion) {
-            container.append(
-                $('<span>').text(` en la región ${suggestionRegion}?`)
-            );
-        } else {
-            container.append($('<span>').text('?'));
-        }
-    }
-
-    function handleInvalidComuna(comunaInput, regionSelect) {
-        const currentValue = comunaInput.val();
-        const normalizedCurrentValue = normalizeString(currentValue);
-
-        if (!normalizedCurrentValue) {
-            clearComunaSuggestion(comunaInput);
-            $(regionSelect).val('').trigger('change');
-            return;
-        }
-
-        const suggestion = findClosestComuna(currentValue);
-        showComunaSuggestion(comunaInput, suggestion, regionSelect);
-        $(regionSelect).val('').trigger('change');
-    }
-
-    // Sincronizar la región con la comuna seleccionada
+    // --- REGION SYNC ---
     function syncRegionWithComuna(comunaInput, regionSelect) {
-        const $comunaInput = $(comunaInput);
-        const $regionSelect = $(regionSelect);
-        const selectedComunaNormalized = normalizeString($comunaInput.val());
-        const associatedRegion = comunaToRegionMap[selectedComunaNormalized];
-        console.log("Comuna entered:", $comunaInput.val());
-        console.log("Normalized comuna:", selectedComunaNormalized);
-        console.log("Associated region:", associatedRegion);
+        const normalized = normalizeString($(comunaInput).val());
+        const region = comunaToRegionMap[normalized];
 
-        if (!associatedRegion) {
-            console.warn("No associated region found for:", selectedComunaNormalized);
-            handleInvalidComuna($comunaInput, regionSelect);
+        console.log("syncRegionWithComuna called for:", $(comunaInput).val(), "→ region:", region);
+
+        if (!region) {
+            console.warn("No region found for:", normalized);
             return;
         }
 
-        const normalizedRegion = normalizeString(associatedRegion);
-        const regionCode = regionCodeMap[normalizedRegion] || null;
-        console.log("Normalized region:", normalizedRegion, "Code:", regionCode);
-
-        let matched = false;
-
-        $regionSelect.find('option').each(function () {
-            const optionText = normalizeString($(this).text());
-            const optionValue = $(this).val().toUpperCase();
-
-            if (
-                optionText === normalizedRegion ||
-                optionText.includes(normalizedRegion) ||
-                normalizedRegion.includes(optionText) ||
-                (regionCode && optionValue === regionCode)
-            ) {
-                console.log("Found matching region option:", optionText, "Value:", optionValue);
-                $regionSelect.val(optionValue).trigger('change');
-                matched = true;
-                clearComunaSuggestion($comunaInput);
-                return false; // break
-            }
+        const normalizedRegion = normalizeString(region);
+        const option = $(`${regionSelect} option`).filter(function () {
+            return normalizeString($(this).text()) === normalizedRegion;
         });
 
-        if (!matched && regionCode) {
-            console.log("No match found in options, setting manually:", regionCode);
-            $regionSelect.val(regionCode).trigger('change');
-            matched = true;
-        }
-
-        if (matched) {
-            console.log("Region successfully set to:", $regionSelect.val());
-            console.log("Region field value now:", $regionSelect.val());
-            // Force WooCommerce recalculation
-            setTimeout(() => {
-                console.log("Triggering WooCommerce update_checkout()");
-                $('body').trigger('update_checkout');
-            }, 500);
+        if (option.length > 0) {
+            const regionValue = option.val();
+            $(regionSelect).val(regionValue).trigger('change');
+            console.log("✅ Region set to:", regionValue);
+            $('body').trigger('update_checkout');
         } else {
-            console.warn("Failed to match any region for:", associatedRegion);
-            handleInvalidComuna($comunaInput, regionSelect);
+            console.warn("⚠️ No matching region option found in select for:", normalizedRegion);
         }
-
-        // Sync shipping state too
-        $('#shipping_state').val($('#billing_state').val()).trigger('change');
     }
 
-    // Inicializar el autocompletado con una función personalizada
-    $('#billing_comuna, #shipping_comuna').autocomplete({
+    // --- AUTOCOMPLETE INITIALIZATION ---
+    $('#billing_city, #shipping_city').autocomplete({
         source: function(request, response) {
             const term = request.term;
-            // Crear una expresión regular que considere la 'Ñ' y 'ñ'
             const regex = new RegExp("^" + $.ui.autocomplete.escapeRegex(term), "i");
-            const matches = comunaList.filter(function(comuna) {
-                return regex.test(comuna);
-            });
+            const matches = comunaList.filter(c => regex.test(c));
             response(matches);
         },
         minLength: 1,
         select: function (event, ui) {
-            const comunaInput = $(this);
-            const regionSelect = comunaInput.attr('id') === 'billing_comuna' ? '#billing_state' : '#shipping_state';
-            comunaInput.val(ui.item.value); // Establecer el valor exacto
-            syncRegionWithComuna(comunaInput, regionSelect);
+            const input = $(this);
+            const regionSelect = input.attr('id') === 'billing_city' ? '#billing_state' : '#shipping_state';
+            input.val(ui.item.value);
+            syncRegionWithComuna(input, regionSelect);
         },
         change: function(event, ui) {
-            const comunaInput = $(this);
-            const regionSelect = comunaInput.attr('id') === 'billing_comuna' ? '#billing_state' : '#shipping_state';
-            const inputValNormalized = normalizeString(comunaInput.val());
+            const input = $(this);
+            const regionSelect = input.attr('id') === 'billing_city' ? '#billing_state' : '#shipping_state';
+            const normalized = normalizeString(input.val());
 
-            if (comunaToRegionMap.hasOwnProperty(inputValNormalized)) {
-                // Obtener el nombre exacto de la comuna
-                const exactComuna = comunaExactMap[inputValNormalized];
-                comunaInput.val(exactComuna);
-                syncRegionWithComuna(comunaInput, regionSelect);
-                return;
-            }
-
-            const closestComuna = findClosestComuna(comunaInput.val());
-            if (closestComuna) {
-                const closestNormalized = normalizeString(closestComuna);
-                const associatedRegion = comunaToRegionMap[closestNormalized];
-
-                if (associatedRegion && closestNormalized === inputValNormalized) {
-                    comunaInput.val(closestComuna);
-                    syncRegionWithComuna(comunaInput, regionSelect);
-                    return;
+            if (comunaToRegionMap.hasOwnProperty(normalized)) {
+                const exact = comunaExactMap[normalized];
+                input.val(exact);
+                syncRegionWithComuna(input, regionSelect);
+            } else {
+                const closest = findClosestComuna(input.val());
+                if (closest) {
+                    input.val(closest);
+                    syncRegionWithComuna(input, regionSelect);
                 }
             }
-
-            handleInvalidComuna(comunaInput, regionSelect);
         }
     });
 
-    $('#billing_comuna, #shipping_comuna').on('input', function () {
-        clearComunaSuggestion($(this));
+    // --- REGION SYNC ON BLUR ---
+    $('#billing_city, #shipping_city').on('blur', function () {
+        const input = $(this);
+        const regionSelect = input.attr('id') === 'billing_city' ? '#billing_state' : '#shipping_state';
+        syncRegionWithComuna(input, regionSelect);
     });
 
-    // Estilizar los campos de región para que no sean editables
-    function styleRegionFields() {
-        $('#billing_state, #shipping_state').css({
-            'background-color': '#f9f9f9'
-        });
-    }
-
-    // Aplicar el estilo al actualizar el checkout
-    $(document.body).on('updated_checkout', function () {
-        styleRegionFields();
-    });
-
-    // Aplicar el estilo inicialmente
-    styleRegionFields();
-
-    // Sincronizar la región al perder el foco del campo comuna
-    // Asegurarse de que los campos de región estén habilitados al enviar el formulario
+    // --- ENSURE STATE IS ENABLED ON SUBMIT ---
     $('form.checkout, form.woocommerce-address-form').on('submit', function () {
         $('#billing_state, #shipping_state').prop('disabled', false);
     });
 
-    $(document.body).on('change', '#billing_state, #shipping_state', function () {
-        $('body').trigger('update_checkout');
+    // --- STYLE REGION FIELDS ---
+    $('#billing_state, #shipping_state').css({
+        'background-color': '#f9f9f9',
+        'pointer-events': 'none',
+        'cursor': 'not-allowed'
     });
 
-    function bindCheckoutComunaEvents() {
-        const comunaSelectors = [
-            { input: '#billing_city', region: '#billing_state', label: 'Billing' },
-            { input: '#billing_comuna', region: '#billing_state', label: 'Billing' },
-            { input: '#shipping_city', region: '#shipping_state', label: 'Shipping' },
-            { input: '#shipping_comuna', region: '#shipping_state', label: 'Shipping' },
-        ];
-
-        comunaSelectors.forEach(({ input, region, label }) => {
-            const $field = $(input);
-
-            if ($field.length) {
-                $field.off('input.wooCheck change.wooCheck blur.wooCheck');
-                $field.on('input.wooCheck change.wooCheck blur.wooCheck', function () {
-                    console.log(`${label} comuna input changed:`, $(this).val());
-                    syncRegionWithComuna($(this), region);
-                });
-            }
-        });
-    }
-
-    console.log("WooCheck Autocomplete initialized");
-    bindCheckoutComunaEvents();
-
-    $(document.body).on('updated_checkout', function () {
-        console.log("WooCommerce checkout updated, re-binding commune events if needed");
-        bindCheckoutComunaEvents();
-    });
+    console.log("✅ WooCheck autocomplete fully initialized.");
 });

--- a/woo-check-autocomplete.js
+++ b/woo-check-autocomplete.js
@@ -16,6 +16,25 @@ jQuery(document).ready(function ($) {
 
     // Crear el mapa comuna -> región utilizando la normalización
     const comunaToRegionMap = {};
+    const regionCodeMap = {
+        'arica y parinacota': 'CL-AP',
+        'tarapaca': 'CL-TA',
+        'antofagasta': 'CL-AN',
+        'atacama': 'CL-AT',
+        'coquimbo': 'CL-CO',
+        'valparaiso': 'CL-VS',
+        'metropolitana de santiago': 'CL-RM',
+        'region metropolitana': 'CL-RM',
+        'libertador general bernardo ohiggins': 'CL-LI',
+        'maule': 'CL-ML',
+        'nuble': 'CL-NB',
+        'biobio': 'CL-BI',
+        'araucania': 'CL-AR',
+        'los rios': 'CL-LR',
+        'los lagos': 'CL-LL',
+        'aysen': 'CL-AI',
+        'magallanes': 'CL-MA'
+    };
     const comunaExactMap = {}; // Mapa para obtener el nombre exacto de la comuna
     comunasChile.forEach(entry => {
         entry.comunas.forEach(comuna => {
@@ -177,7 +196,9 @@ jQuery(document).ready(function ($) {
             return;
         }
 
-        const normalizedAssociatedRegion = normalizeString(associatedRegion);
+        const normalizedRegion = normalizeString(associatedRegion);
+        const regionCode = regionCodeMap[normalizedRegion] || null;
+
         let matched = false;
 
         $(`${regionSelect} option`).each(function () {
@@ -185,9 +206,10 @@ jQuery(document).ready(function ($) {
             const optionValue = $(this).val().toUpperCase();
 
             if (
-                optionText === normalizedAssociatedRegion ||
-                optionText.includes(normalizedAssociatedRegion) ||
-                normalizedAssociatedRegion.includes(optionText)
+                optionText === normalizedRegion ||
+                optionText.includes(normalizedRegion) ||
+                normalizedRegion.includes(optionText) ||
+                (regionCode && optionValue === regionCode)
             ) {
                 $(regionSelect).val(optionValue).trigger('change');
                 $('body').trigger('update_checkout');
@@ -197,8 +219,8 @@ jQuery(document).ready(function ($) {
             }
         });
 
-        if (!matched && normalizedAssociatedRegion.includes('metropolitana')) {
-            $(regionSelect).val('CL-RM').trigger('change');
+        if (!matched && regionCode) {
+            $(regionSelect).val(regionCode).trigger('change');
             $('body').trigger('update_checkout');
             clearComunaSuggestion(comunaInput);
             matched = true;

--- a/woo-check-autocomplete.js
+++ b/woo-check-autocomplete.js
@@ -3,6 +3,19 @@
 console.log("✅ WooCheck JS file LOADED at top of script");
 
 jQuery(document).ready(function ($) {
+    // Ensure billing_country exists and is set to Chile
+    if (!jQuery('#billing_country').length) {
+        jQuery('<input>', {
+            type: 'hidden',
+            id: 'billing_country',
+            name: 'billing_country',
+            value: 'CL'
+        }).appendTo('form.checkout');
+        console.log("✅ billing_country field added automatically: CL");
+    } else {
+        jQuery('#billing_country').val('CL').trigger('change');
+    }
+
     console.log("✅ jQuery(document).ready() is running");
     console.log("jQuery version:", $.fn.jquery);
     console.log("billing_city exists?", $('#billing_city').length > 0);

--- a/woo-check-autocomplete.js
+++ b/woo-check-autocomplete.js
@@ -190,14 +190,19 @@ jQuery(document).ready(function ($) {
     function syncRegionWithComuna(comunaInput, regionSelect) {
         const selectedComunaNormalized = normalizeString($(comunaInput).val());
         const associatedRegion = comunaToRegionMap[selectedComunaNormalized];
+        console.log("Comuna entered:", $(comunaInput).val());
+        console.log("Normalized comuna:", selectedComunaNormalized);
+        console.log("Associated region:", associatedRegion);
 
         if (!associatedRegion) {
+            console.warn("No associated region found for:", selectedComunaNormalized);
             handleInvalidComuna(comunaInput, regionSelect);
             return;
         }
 
         const normalizedRegion = normalizeString(associatedRegion);
         const regionCode = regionCodeMap[normalizedRegion] || null;
+        console.log("Normalized region:", normalizedRegion, "Code:", regionCode);
 
         let matched = false;
 
@@ -211,24 +216,34 @@ jQuery(document).ready(function ($) {
                 normalizedRegion.includes(optionText) ||
                 (regionCode && optionValue === regionCode)
             ) {
+                console.log("Found matching region option:", optionText, "Value:", optionValue);
                 $(regionSelect).val(optionValue).trigger('change');
-                $('body').trigger('update_checkout');
                 matched = true;
                 clearComunaSuggestion(comunaInput);
-                return false;
+                return false; // break
             }
         });
 
         if (!matched && regionCode) {
+            console.log("No match found in options, setting manually:", regionCode);
             $(regionSelect).val(regionCode).trigger('change');
-            $('body').trigger('update_checkout');
-            clearComunaSuggestion(comunaInput);
             matched = true;
         }
 
-        if (!matched) {
+        if (matched) {
+            console.log("Region successfully set to:", $(regionSelect).val());
+            // Force WooCommerce recalculation
+            setTimeout(() => {
+                console.log("Triggering WooCommerce update_checkout()");
+                $('body').trigger('update_checkout');
+            }, 500);
+        } else {
+            console.warn("Failed to match any region for:", associatedRegion);
             handleInvalidComuna(comunaInput, regionSelect);
         }
+
+        // Sync shipping state too
+        $('#shipping_state').val($('#billing_state').val()).trigger('change');
     }
 
     // Inicializar el autocompletado con una función personalizada


### PR DESCRIPTION
## Summary
- improve commune-to-region syncing to match WooCommerce state codes and handle Metropolitana fallback
- allow region fields to remain submitable while still styled as read-only and trigger checkout refreshes on change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e521792c6c8332a8e206408c337f2e