### PR TITLE
Ensure quiz average helper is shared with first-quiz email

### DIFF
--- a/emails/first-quiz-email.php
+++ b/emails/first-quiz-email.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Shared logic for the "First Quiz" transactional email.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! function_exists( 'woo_check_prepare_first_quiz_email_data' ) ) {
+    /**
+     * Prepare the metrics used by the "First Quiz" email template.
+     *
+     * @param int        $quiz_post_id Quiz identifier.
+     * @param float|null $user_score   Normalized user score.
+     * @return array{average_score:float|null,user_score:float|null}
+     */
+    function woo_check_prepare_first_quiz_email_data( int $quiz_post_id, ?float $user_score ): array {
+        $average_score = null;
+
+        if ( $quiz_post_id ) {
+            if ( class_exists( 'Polis_Quiz_Average_Helper' ) ) {
+                sleep( 1 );
+                $average_score = Polis_Quiz_Average_Helper::get_average_for_quiz( $quiz_post_id );
+                error_log( '[FirstQuizEmail] Average via Polis_Quiz_Average_Helper=' . print_r( $average_score, true ) );
+            } elseif ( class_exists( 'Polis_Quiz_Attempts_Shortcode' ) && method_exists( 'Polis_Quiz_Attempts_Shortcode', 'get_polis_average_for_quiz' ) ) {
+                sleep( 1 );
+                $average_score = Polis_Quiz_Attempts_Shortcode::get_polis_average_for_quiz( $quiz_post_id );
+                error_log( '[FirstQuizEmail] Average via Polis_Quiz_Attempts_Shortcode=' . print_r( $average_score, true ) );
+            } elseif ( class_exists( 'Villegas_Quiz_Stats' ) && method_exists( 'Villegas_Quiz_Stats', 'get_average_percentage' ) ) {
+                sleep( 1 );
+                $average_score = Villegas_Quiz_Stats::get_average_percentage( $quiz_post_id );
+                error_log( '[FirstQuizEmail] Average via Villegas_Quiz_Stats=' . print_r( $average_score, true ) );
+            }
+        }
+
+        error_log( '[FirstQuizEmail] Average (raw)=' . print_r( $average_score, true ) );
+        error_log( '[FirstQuizEmail] User score (normalized)=' . print_r( $user_score, true ) );
+
+        return [
+            'average_score' => $average_score,
+            'user_score'    => $user_score,
+        ];
+    }
+}

--- a/includes/polis-average-quiz-result.php
+++ b/includes/polis-average-quiz-result.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Shared helper for retrieving the filtered Polis quiz average.
+ */
+
+if ( ! class_exists( 'Polis_Quiz_Average_Helper' ) ) {
+    class Polis_Quiz_Average_Helper {
+        /**
+         * Fetch the most up-to-date quiz average using the same logic as the frontend shortcode.
+         *
+         * @param int $quiz_id Quiz identifier.
+         * @return float|null Average percentage or null when unavailable.
+         */
+        public static function get_average_for_quiz( int $quiz_id ): ?float {
+            if ( $quiz_id <= 0 ) {
+                return null;
+            }
+
+            if ( class_exists( 'Polis_Quiz_Attempts_Shortcode' ) && method_exists( 'Polis_Quiz_Attempts_Shortcode', 'get_polis_average_for_quiz' ) ) {
+                return Polis_Quiz_Attempts_Shortcode::get_polis_average_for_quiz( $quiz_id );
+            }
+
+            if ( class_exists( 'Villegas_Quiz_Stats' ) && method_exists( 'Villegas_Quiz_Stats', 'get_average_percentage' ) ) {
+                return Villegas_Quiz_Stats::get_average_percentage( $quiz_id );
+            }
+
+            return null;
+        }
+    }
+}

--- a/woo-check.php
+++ b/woo-check.php
@@ -13,6 +13,8 @@ if (!defined('ABSPATH')) {
 
 // Include email customizations
 require_once plugin_dir_path( __FILE__ ) . 'includes/email-customizations.php';
+require_once plugin_dir_path( __FILE__ ) . 'emails/first-quiz-email.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/polis-average-quiz-result.php';
 // Include the plugin's functions.php file
 require_once plugin_dir_path(__FILE__) . 'functions.php';
 // Load WooCheck logistics dependencies


### PR DESCRIPTION
## Summary
- add a shared helper that defers to the Polis quiz shortcode average logic
- update the first quiz email workflow to consume the helper and add logging to compare averages
- bootstrap the plugin with the new helper/email utilities so both contexts use the same data source

## Testing
- php -l includes/polis-average-quiz-result.php
- php -l emails/first-quiz-email.php

------
https://chatgpt.com/codex/tasks/task_e_68e8555aec1483328bf982490f82a762