### PR TITLE
Update email header styling and course button font size

### DIFF
--- a/templates/checkout/order-received.php
+++ b/templates/checkout/order-received.php
@@ -195,7 +195,7 @@ $order = wc_get_order($order_id);
                                 <?php if ($course_url) : ?>
                                     <!-- Show only the product name without quantity for courses -->
                                     <span><?php echo esc_html($product_name); ?></span>
-                                    <br><a href="<?php echo esc_url($course_url); ?>" class="button" style="display: inline-block; margin-top: 10px; padding: 5px 10px; background-color: black; color: #fff; text-decoration: none; border-radius: 3px; font-size: 12px;">Ir al Curso</a>
+                                    <br><a href="<?php echo esc_url($course_url); ?>" class="button" style="display: inline-block; margin-top: 10px; padding: 5px 10px; background-color: black; color: #fff; text-decoration: none; border-radius: 3px; font-size: 13px;">Ir al Curso</a>
                                 <?php else : ?>
                                     <!-- Show product name with quantity for non-courses -->
                                     <span><?php echo esc_html($product_quantity); ?> - <?php echo esc_html($product_name); ?></span>

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -49,7 +49,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 										<tr>
 											<td align="center" valign="top">
 												<!-- Header -->
-												<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_header">
+                                                                                                <table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_header" class="villegas-email-encabezado">
 													<tr>
 														<td id="header_wrapper">
 															<h1><?php echo esc_html( $email_heading ); ?></h1>

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -70,14 +70,19 @@ body {
 }
 
 #template_header {
-	background-color: <?php echo esc_attr( $base ); ?>;
-	border-radius: 3px 3px 0 0 !important;
-	color: <?php echo esc_attr( $base_text ); ?>;
-	border-bottom: 0;
-	font-weight: bold;
-	line-height: 100%;
-	vertical-align: middle;
-	font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+        background-color: <?php echo esc_attr( $base ); ?>;
+        border-radius: 3px 3px 0 0 !important;
+        color: <?php echo esc_attr( $base_text ); ?>;
+        border-bottom: 0;
+        font-weight: bold;
+        line-height: 100%;
+        vertical-align: middle;
+        font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+}
+
+.villegas-email-encabezado {
+        border-radius: 10px 10px 0 0 !important;
+        overflow: hidden;
 }
 
 #template_header h1,


### PR DESCRIPTION
## Summary
- add the `villegas-email-encabezado` class to the WooCommerce email header markup and style it with rounded top corners and hidden overflow
- increase the inline font size for the "Ir al Curso" course access button to improve readability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8610c91988332b97d71d428d59919