### PR TITLE
Add region column to Villegas packing list shortcode

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -78,6 +78,114 @@ function villegas_packing_list_shortcode( $atts ) {
         return '<p>' . esc_html__( 'There are no processing orders at the moment.', 'woo-check' ) . '</p>';
     }
 
+    $determine_region_label = static function ( WC_Order $order ) {
+        $region_name = '';
+
+        if ( function_exists( 'wc_check_determine_commune_region_data' ) ) {
+            $location = wc_check_determine_commune_region_data( $order );
+
+            if ( ! empty( $location['region_name'] ) ) {
+                $region_name = $location['region_name'];
+            }
+        }
+
+        if ( '' === $region_name ) {
+            $region_name = $order->get_shipping_state() ?: $order->get_billing_state();
+        }
+
+        return $region_name;
+    };
+
+    $normalize_region_name = static function ( $region_name ) {
+        $region_name = (string) $region_name;
+
+        if ( class_exists( 'WooCheck_Shipit_Validator' ) && method_exists( 'WooCheck_Shipit_Validator', 'normalize_commune' ) ) {
+            return WooCheck_Shipit_Validator::normalize_commune( $region_name );
+        }
+
+        if ( function_exists( 'remove_accents' ) ) {
+            $region_name = remove_accents( $region_name );
+        }
+
+        return strtoupper( trim( $region_name ) );
+    };
+
+    $is_metropolitana_order = static function ( WC_Order $order, $region_label ) use ( $normalize_region_name ) {
+        $normalized_region = '' !== $region_label ? $normalize_region_name( $region_label ) : '';
+
+        if ( '' !== $normalized_region && false !== strpos( $normalized_region, 'METROPOLITANA' ) ) {
+            return true;
+        }
+
+        $shipping_state = strtoupper( (string) $order->get_shipping_state() );
+        $billing_state  = strtoupper( (string) $order->get_billing_state() );
+
+        $metropolitana_states = [ 'RM', 'CL-RM' ];
+
+        return in_array( $shipping_state, $metropolitana_states, true ) || in_array( $billing_state, $metropolitana_states, true );
+    };
+
+    $summary_counts = [
+        'new_orders_today'     => 0,
+        'region_metropolitana' => 0,
+        'other_regions'        => 0,
+    ];
+
+    $order_region_cache = [];
+
+    $summary_orders = wc_get_orders(
+        [
+            'status' => 'processing',
+            'limit'  => -1,
+            'return' => 'objects',
+        ]
+    );
+
+    if ( is_array( $summary_orders ) ) {
+        $current_timestamp = current_time( 'timestamp' );
+        $today_start_ts    = strtotime( 'today', $current_timestamp );
+        $today_end_ts      = strtotime( 'tomorrow', $today_start_ts );
+
+        if ( false === $today_start_ts ) {
+            $today_start_ts = strtotime( 'today' );
+        }
+
+        if ( false === $today_start_ts ) {
+            $today_start_ts = (int) $current_timestamp;
+        }
+
+        if ( false === $today_end_ts ) {
+            $day_in_seconds = defined( 'DAY_IN_SECONDS' ) ? DAY_IN_SECONDS : 86400;
+            $today_end_ts   = (int) $today_start_ts + $day_in_seconds;
+        }
+
+        foreach ( $summary_orders as $summary_order ) {
+            if ( ! $summary_order instanceof WC_Order ) {
+                continue;
+            }
+
+            $order_id                = $summary_order->get_id();
+            $region_label            = $determine_region_label( $summary_order );
+            $order_region_cache[ $order_id ] = $region_label;
+
+            $date_created = $summary_order->get_date_created();
+
+            if ( $date_created instanceof WC_DateTime ) {
+                $order_timestamp = $date_created->getTimestamp();
+
+                if ( $order_timestamp >= $today_start_ts && $order_timestamp < $today_end_ts ) {
+                    $summary_counts['new_orders_today']++;
+                }
+            }
+
+            if ( $is_metropolitana_order( $summary_order, $region_label ) ) {
+                $summary_counts['region_metropolitana']++;
+            } else {
+                $summary_counts['other_regions']++;
+            }
+        }
+    }
+
     ob_start();
 
     static $packing_assets_printed = false;
@@ -137,6 +245,27 @@ function villegas_packing_list_shortcode( $atts ) {
             }
 
             .villegas-packing-pagination__status {
+                font-weight: 600;
+            }
+
+            #villegas-packing-summary {
+                border: 1px solid #ccc;
+                padding: 12px;
+                margin-bottom: 12px;
+                display: flex;
+                flex-wrap: wrap;
+                gap: 16px;
+                background: #fff;
+            }
+
+            #villegas-packing-summary .villegas-packing-summary__item {
+                display: flex;
+                align-items: baseline;
+                gap: 6px;
+                font-size: 14px;
+            }
+
+            #villegas-packing-summary .villegas-packing-summary__label {
                 font-weight: 600;
             }
         </style>
@@ -206,6 +335,21 @@ function villegas_packing_list_shortcode( $atts ) {
     }
 
     ?>
+    <div id="villegas-packing-summary">
+        <div class="villegas-packing-summary__item">
+            <span class="villegas-packing-summary__label"><?php esc_html_e( 'New Orders Today', 'woo-check' ); ?>:</span>
+            <span class="villegas-packing-summary__value"><?php echo esc_html( number_format_i18n( $summary_counts['new_orders_today'] ) ); ?></span>
+        </div>
+        <div class="villegas-packing-summary__item">
+            <span class="villegas-packing-summary__label"><?php esc_html_e( 'Region Metropolitana', 'woo-check' ); ?>:</span>
+            <span class="villegas-packing-summary__value"><?php echo esc_html( number_format_i18n( $summary_counts['region_metropolitana'] ) ); ?></span>
+        </div>
+        <div class="villegas-packing-summary__item">
+            <span class="villegas-packing-summary__label"><?php esc_html_e( 'Other Regions', 'woo-check' ); ?>:</span>
+            <span class="villegas-packing-summary__value"><?php echo esc_html( number_format_i18n( $summary_counts['other_regions'] ) ); ?></span>
+        </div>
+    </div>
+
     <table class="villegas-packing-list">
         <thead>
             <tr>
@@ -213,8 +357,8 @@ function villegas_packing_list_shortcode( $atts ) {
                     <span class="screen-reader-text"><?php esc_html_e( 'Select order', 'woo-check' ); ?></span>
                 </th>
                 <th><?php esc_html_e( 'Order ID', 'woo-check' ); ?></th>
-                <th><?php esc_html_e( 'Region', 'woo-check' ); ?></th>
                 <th><?php esc_html_e( 'Items', 'woo-check' ); ?></th>
+                <th><?php esc_html_e( 'Region', 'woo-check' ); ?></th>
             </tr>
         </thead>
         <tbody>
@@ -232,25 +376,6 @@ function villegas_packing_list_shortcode( $atts ) {
                     <td><?php echo esc_html( $order->get_id() ); ?></td>
                     <td>
                         <?php
-                        $region_name = '';
-
-                        if ( function_exists( 'wc_check_determine_commune_region_data' ) ) {
-                            $location = wc_check_determine_commune_region_data( $order );
-
-                            if ( ! empty( $location['region_name'] ) ) {
-                                $region_name = $location['region_name'];
-                            }
-                        }
-
-                        if ( '' === $region_name ) {
-                            $region_name = $order->get_shipping_state() ?: $order->get_billing_state();
-                        }
-
-                        echo esc_html( $region_name );
-                        ?>
-                    </td>
-                    <td>
-                        <?php
                         $item_lines = [];
 
                         foreach ( $order->get_items() as $item ) {
@@ -264,6 +389,14 @@ function villegas_packing_list_shortcode( $atts ) {
                         }
 
                         echo wp_kses_post( implode( '<br />', $item_lines ) );
+                        ?>
+                    </td>
+                    <td>
+                        <?php
+                        $order_id    = $order->get_id();
+                        $region_name = $order_region_cache[ $order_id ] ?? $determine_region_label( $order );
+
+                        echo esc_html( $region_name );
                         ?>
                     </td>
                 </tr>

--- a/functions.php
+++ b/functions.php
@@ -213,6 +213,7 @@ function villegas_packing_list_shortcode( $atts ) {
                     <span class="screen-reader-text"><?php esc_html_e( 'Select order', 'woo-check' ); ?></span>
                 </th>
                 <th><?php esc_html_e( 'Order ID', 'woo-check' ); ?></th>
+                <th><?php esc_html_e( 'Region', 'woo-check' ); ?></th>
                 <th><?php esc_html_e( 'Items', 'woo-check' ); ?></th>
             </tr>
         </thead>
@@ -229,6 +230,25 @@ function villegas_packing_list_shortcode( $atts ) {
                         />
                     </td>
                     <td><?php echo esc_html( $order->get_id() ); ?></td>
+                    <td>
+                        <?php
+                        $region_name = '';
+
+                        if ( function_exists( 'wc_check_determine_commune_region_data' ) ) {
+                            $location = wc_check_determine_commune_region_data( $order );
+
+                            if ( ! empty( $location['region_name'] ) ) {
+                                $region_name = $location['region_name'];
+                            }
+                        }
+
+                        if ( '' === $region_name ) {
+                            $region_name = $order->get_shipping_state() ?: $order->get_billing_state();
+                        }
+
+                        echo esc_html( $region_name );
+                        ?>
+                    </td>
                     <td>
                         <?php
                         $item_lines = [];

--- a/functions.php
+++ b/functions.php
@@ -169,19 +169,23 @@ function villegas_packing_list_shortcode( $atts ) {
             $order_region_cache[ $order_id ] = $region_label;
 
             $date_created = $summary_order->get_date_created();
+            $is_today     = false;
 
             if ( $date_created instanceof WC_DateTime ) {
                 $order_timestamp = $date_created->getTimestamp();
 
                 if ( $order_timestamp >= $today_start_ts && $order_timestamp < $today_end_ts ) {
                     $summary_counts['new_orders_today']++;
+                    $is_today = true;
                 }
             }
 
-            if ( $is_metropolitana_order( $summary_order, $region_label ) ) {
-                $summary_counts['region_metropolitana']++;
-            } else {
-                $summary_counts['other_regions']++;
+            if ( $is_today ) {
+                if ( $is_metropolitana_order( $summary_order, $region_label ) ) {
+                    $summary_counts['region_metropolitana']++;
+                } else {
+                    $summary_counts['other_regions']++;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a Region column to the villegas-packing-list shortcode output
- populate the column using the commune/region data helper with a fallback to the shipping or billing state

## Testing
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68e9011bdeac8332a73aea559fe6d90e