### PR TITLE
Add packing and inventory view switch

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1056,7 +1056,13 @@ function villegas_packing_list_shortcode( $atts ) {
         </div>
     </div>
     <div id="inventory-stats-page" style="display:none;">
-        <!-- Inventory stats placeholder -->
+        <?php
+        $inventory_view = __DIR__ . '/views/inventory.php';
+
+        if ( file_exists( $inventory_view ) ) {
+            include $inventory_view;
+        }
+        ?>
     </div>
     <script>
         document.addEventListener( 'DOMContentLoaded', function () {

--- a/functions.php
+++ b/functions.php
@@ -305,36 +305,24 @@ function villegas_packing_list_shortcode( $atts ) {
         $packing_assets_printed = true;
         ?>
         <style>
-            .packing-stats-nav {
-                display: flex;
-                gap: 12px;
+            .villegas-toolbar-switch {
+                text-align: center;
                 margin-bottom: 20px;
-            }
-
-            .packing-stats-nav__link {
-                display: inline-flex;
-                align-items: center;
-                justify-content: center;
-                padding: 8px 20px;
-                border: 1px solid #d0d5dd;
-                border-radius: 999px;
-                background: #fff;
-                color: #1f2937;
                 font-weight: 600;
+                font-size: 1.1rem;
+            }
+
+            .villegas-toolbar-switch a {
+                color: #555;
                 text-decoration: none;
-                transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+                margin: 0 10px;
+                padding-bottom: 3px;
+                border-bottom: 2px solid transparent;
             }
 
-            .packing-stats-nav__link:hover,
-            .packing-stats-nav__link:focus {
-                background: #f8fafc;
-            }
-
-            .packing-stats-nav__link.is-active {
-                background: #1f2937;
-                border-color: #1f2937;
-                color: #fff;
-                box-shadow: 0 0 0 1px rgba(31, 41, 55, 0.15);
+            .villegas-toolbar-switch a.active {
+                color: black;
+                border-bottom: 2px solid black;
             }
 
             .villegas-packing-list {
@@ -675,9 +663,9 @@ function villegas_packing_list_shortcode( $atts ) {
     }
 
     ?>
-    <div class="packing-stats-nav">
-        <a href="#" class="packing-stats-nav__link is-active" data-target="packing-stats-page"><?php esc_html_e( 'PACKING', 'woo-check' ); ?></a>
-        <a href="#" class="packing-stats-nav__link" data-target="inventory-stats-page"><?php esc_html_e( 'INVENTORY', 'woo-check' ); ?></a>
+    <div class="villegas-toolbar-switch">
+        <a href="#" id="show-packing" class="active"><?php esc_html_e( 'PACKING', 'woo-check' ); ?></a> |
+        <a href="#" id="show-inventory"><?php esc_html_e( 'INVENTORY', 'woo-check' ); ?></a>
     </div>
     <div id="packing-stats-page">
         <div id="packing-stats">
@@ -997,7 +985,7 @@ function villegas_packing_list_shortcode( $atts ) {
     }
 
     ?>
-        <div class="villegas-packing-toolbar">
+        <div id="villegas-packing-toolbar" class="villegas-packing-toolbar">
             <div class="packing-region-toggle" role="group" aria-label="<?php esc_attr_e( 'Filter orders by region', 'woo-check' ); ?>">
                 <button type="button" class="packing-region-toggle__button is-active" data-region-filter="all" aria-pressed="true">
                     <?php echo esc_html_x( 'ALL', 'Filter region option for all orders', 'woo-check' ); ?>
@@ -1011,109 +999,92 @@ function villegas_packing_list_shortcode( $atts ) {
             </div>
             <?php echo $pagination_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
         </div>
-        <table class="villegas-packing-list">
-            <thead>
-                <tr>
-                    <th class="packing-select">
-                    <span class="screen-reader-text"><?php esc_html_e( 'Select order', 'woo-check' ); ?></span>
-                </th>
-                <th><?php esc_html_e( 'Order ID', 'woo-check' ); ?></th>
-                <th><?php esc_html_e( 'Items', 'woo-check' ); ?></th>
-                <th><?php esc_html_e( 'Region', 'woo-check' ); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php foreach ( $orders as $order ) : ?>
-                <?php if ( ! $order instanceof WC_Order ) { continue; } ?>
-                <?php
-                $order_id    = $order->get_id();
-                $region_name = $order_region_cache[ $order_id ] ?? $determine_region_label( $order );
-                $region_type = $is_metropolitana_order( $order, $region_name ) ? 'rm' : 'non-rm';
-                ?>
-                <tr data-region-group="<?php echo esc_attr( $region_type ); ?>">
-                    <td>
-                        <input
-                            type="checkbox"
-                            class="packing-checkbox"
-                            data-order-id="<?php echo esc_attr( $order->get_id() ); ?>"
-                            aria-label="<?php echo esc_attr( sprintf( __( 'Select order %d', 'woo-check' ), $order->get_id() ) ); ?>"
-                        />
-                    </td>
-                    <td><?php echo esc_html( $order->get_id() ); ?></td>
-                    <td>
-                        <?php
-                        $item_lines = [];
-
-                        foreach ( $order->get_items() as $item ) {
-                            $line = sprintf(
-                                '%s - %s',
-                                $item->get_name(),
-                                wc_stock_amount( $item->get_quantity() )
-                            );
-
-                            $item_lines[] = esc_html( $line );
-                        }
-
-                        echo wp_kses_post( implode( '<br />', $item_lines ) );
-                        ?>
-                    </td>
-                    <td>
-                        <?php echo esc_html( $region_name ); ?>
-                    </td>
+        <div id="villegas-packing-list">
+            <table class="villegas-packing-list">
+                <thead>
+                    <tr>
+                        <th class="packing-select">
+                        <span class="screen-reader-text"><?php esc_html_e( 'Select order', 'woo-check' ); ?></span>
+                    </th>
+                    <th><?php esc_html_e( 'Order ID', 'woo-check' ); ?></th>
+                    <th><?php esc_html_e( 'Items', 'woo-check' ); ?></th>
+                    <th><?php esc_html_e( 'Region', 'woo-check' ); ?></th>
                 </tr>
-            <?php endforeach; ?>
-        </tbody>
-        </table>
-    </div>
-    <div id="inventory-stats-page" hidden></div>
-    <script>
-        ( function () {
-            var navLinks = document.querySelectorAll( '.packing-stats-nav__link' );
+            </thead>
+            <tbody>
+                <?php foreach ( $orders as $order ) : ?>
+                    <?php if ( ! $order instanceof WC_Order ) { continue; } ?>
+                    <?php
+                    $order_id    = $order->get_id();
+                    $region_name = $order_region_cache[ $order_id ] ?? $determine_region_label( $order );
+                    $region_type = $is_metropolitana_order( $order, $region_name ) ? 'rm' : 'non-rm';
+                    ?>
+                    <tr data-region-group="<?php echo esc_attr( $region_type ); ?>">
+                        <td>
+                            <input
+                                type="checkbox"
+                                class="packing-checkbox"
+                                data-order-id="<?php echo esc_attr( $order->get_id() ); ?>"
+                                aria-label="<?php echo esc_attr( sprintf( __( 'Select order %d', 'woo-check' ), $order->get_id() ) ); ?>"
+                            />
+                        </td>
+                        <td><?php echo esc_html( $order->get_id() ); ?></td>
+                        <td>
+                            <?php
+                            $item_lines = [];
 
-            if ( ! navLinks.length ) {
+                            foreach ( $order->get_items() as $item ) {
+                                $line = sprintf(
+                                    '%s - %s',
+                                    $item->get_name(),
+                                    wc_stock_amount( $item->get_quantity() )
+                                );
+
+                                $item_lines[] = esc_html( $line );
+                            }
+
+                            echo wp_kses_post( implode( '<br />', $item_lines ) );
+                            ?>
+                        </td>
+                        <td>
+                            <?php echo esc_html( $region_name ); ?>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+            </table>
+        </div>
+    </div>
+    <div id="inventory-stats-page" style="display:none;">
+        <!-- Inventory stats placeholder -->
+    </div>
+    <script>
+        document.addEventListener( 'DOMContentLoaded', function () {
+            var packingPage = document.getElementById( 'packing-stats-page' );
+            var inventoryPage = document.getElementById( 'inventory-stats-page' );
+            var showPacking = document.getElementById( 'show-packing' );
+            var showInventory = document.getElementById( 'show-inventory' );
+
+            if ( ! packingPage || ! inventoryPage || ! showPacking || ! showInventory ) {
                 return;
             }
 
-            var sections = {
-                'packing-stats-page': document.getElementById( 'packing-stats-page' ),
-                'inventory-stats-page': document.getElementById( 'inventory-stats-page' )
-            };
-
-            var setActiveSection = function ( targetId, activeLink ) {
-                if ( ! targetId || ! sections[ targetId ] ) {
-                    return;
-                }
-
-                navLinks.forEach( function ( navLink ) {
-                    navLink.classList.toggle( 'is-active', navLink === activeLink );
-                } );
-
-                Object.keys( sections ).forEach( function ( sectionId ) {
-                    if ( ! sections[ sectionId ] ) {
-                        return;
-                    }
-
-                    if ( sectionId === targetId ) {
-                        sections[ sectionId ].removeAttribute( 'hidden' );
-                    } else {
-                        sections[ sectionId ].setAttribute( 'hidden', 'hidden' );
-                    }
-                } );
-            };
-
-            navLinks.forEach( function ( link ) {
-                link.addEventListener( 'click', function ( event ) {
-                    event.preventDefault();
-                    setActiveSection( link.getAttribute( 'data-target' ), link );
-                } );
+            showPacking.addEventListener( 'click', function ( event ) {
+                event.preventDefault();
+                packingPage.style.display = 'block';
+                inventoryPage.style.display = 'none';
+                showPacking.classList.add( 'active' );
+                showInventory.classList.remove( 'active' );
             } );
 
-            var defaultLink = document.querySelector( '.packing-stats-nav__link.is-active' ) || navLinks[ 0 ];
-
-            if ( defaultLink ) {
-                setActiveSection( defaultLink.getAttribute( 'data-target' ), defaultLink );
-            }
-        } )();
+            showInventory.addEventListener( 'click', function ( event ) {
+                event.preventDefault();
+                packingPage.style.display = 'none';
+                inventoryPage.style.display = 'block';
+                showInventory.classList.add( 'active' );
+                showPacking.classList.remove( 'active' );
+            } );
+        } );
     </script>
     <?php
 

--- a/views/inventory.php
+++ b/views/inventory.php
@@ -40,30 +40,31 @@ $books = wc_get_products(
 );
 
 ?>
-<div class="inventory-header">
-    <form method="get">
-        <label>
-            <?php esc_html_e( 'Start Date:', 'woo-check' ); ?>
+<div class="inventory-container">
+    <div class="inventory-header">
+        <form method="get" class="inventory-filter-form">
+            <label>
+                <?php esc_html_e( 'Start Date:', 'woo-check' ); ?>
+            </label>
             <input type="date" name="start_date" value="<?php echo esc_attr( $start_date ); ?>">
-        </label>
-        <label>
-            <?php esc_html_e( 'End Date:', 'woo-check' ); ?>
+            <label>
+                <?php esc_html_e( 'End Date:', 'woo-check' ); ?>
+            </label>
             <input type="date" name="end_date" value="<?php echo esc_attr( $end_date ); ?>">
-        </label>
-        <button type="submit" class="button">
-            <?php esc_html_e( 'Apply', 'woo-check' ); ?>
-        </button>
-    </form>
-</div>
-<table class="inventory-table">
-    <thead>
-        <tr>
-            <th><?php esc_html_e( 'Libro', 'woo-check' ); ?></th>
-            <th><?php esc_html_e( 'Vendidos', 'woo-check' ); ?></th>
-            <th><?php esc_html_e( 'Stock actual', 'woo-check' ); ?></th>
-        </tr>
-    </thead>
-    <tbody>
+            <button type="submit" class="button">
+                <?php esc_html_e( 'Apply', 'woo-check' ); ?>
+            </button>
+        </form>
+    </div>
+    <table class="inventory-table">
+        <thead>
+            <tr>
+                <th><?php esc_html_e( 'Libro', 'woo-check' ); ?></th>
+                <th><?php esc_html_e( 'Vendidos', 'woo-check' ); ?></th>
+                <th><?php esc_html_e( 'Stock actual', 'woo-check' ); ?></th>
+            </tr>
+        </thead>
+        <tbody>
         <?php
         global $wpdb;
 
@@ -109,5 +110,74 @@ $books = wc_get_products(
             <?php
         }
         ?>
-    </tbody>
-</table>
+        </tbody>
+    </table>
+</div>
+
+<style>
+.inventory-container {
+    width: 90%;
+    max-width: 900px;
+    margin: 30px auto;
+    font-family: system-ui, sans-serif;
+}
+
+.inventory-header {
+    text-align: left;
+    margin-bottom: 20px;
+}
+
+.inventory-filter-form {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    font-size: 15px;
+    color: #333;
+}
+
+.inventory-filter-form label {
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.inventory-filter-form input[type="date"] {
+    padding: 6px 10px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 15px;
+}
+
+.inventory-table {
+    width: 100%;
+    border-collapse: collapse;
+    border: 1px solid #ddd;
+    font-size: 15px;
+    background: #fff;
+}
+
+.inventory-table thead {
+    background: #f6f6f6;
+    border-bottom: 2px solid #ccc;
+}
+
+.inventory-table th {
+    text-align: left;
+    padding: 12px 14px;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: #222;
+    border-bottom: 1px solid #ddd;
+    letter-spacing: 0.04em;
+}
+
+.inventory-table td {
+    padding: 12px 14px;
+    border-bottom: 1px solid #eee;
+    color: #333;
+}
+
+.inventory-table tr:hover {
+    background: #fafafa;
+}
+</style>

--- a/views/inventory.php
+++ b/views/inventory.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Inventory view for Libro category products.
+ *
+ * @package Woo_Check
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+$current_time    = current_time( 'timestamp' );
+$default_start   = wp_date( 'Y-m-d', $current_time - WEEK_IN_SECONDS );
+$default_end     = wp_date( 'Y-m-d', $current_time );
+$raw_start_date  = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( $_GET['start_date'] ) ) : $default_start;
+$raw_end_date    = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( $_GET['end_date'] ) ) : $default_end;
+$start_date      = $raw_start_date;
+$end_date        = $raw_end_date;
+
+// Ensure valid dates in Y-m-d format.
+if ( ! wp_checkdate( substr( $start_date, 5, 2 ), substr( $start_date, 8, 2 ), substr( $start_date, 0, 4 ), $start_date ) ) {
+    $start_date = $default_start;
+}
+
+if ( ! wp_checkdate( substr( $end_date, 5, 2 ), substr( $end_date, 8, 2 ), substr( $end_date, 0, 4 ), $end_date ) ) {
+    $end_date = $default_end;
+}
+
+$start_datetime = $start_date . ' 00:00:00';
+$end_datetime   = $end_date . ' 23:59:59';
+
+$books = wc_get_products(
+    [
+        'status'   => 'publish',
+        'category' => [ 'libro' ],
+        'limit'    => -1,
+        'orderby'  => 'title',
+        'order'    => 'ASC',
+    ]
+);
+
+?>
+<div class="inventory-header">
+    <form method="get">
+        <label>
+            <?php esc_html_e( 'Start Date:', 'woo-check' ); ?>
+            <input type="date" name="start_date" value="<?php echo esc_attr( $start_date ); ?>">
+        </label>
+        <label>
+            <?php esc_html_e( 'End Date:', 'woo-check' ); ?>
+            <input type="date" name="end_date" value="<?php echo esc_attr( $end_date ); ?>">
+        </label>
+        <button type="submit" class="button">
+            <?php esc_html_e( 'Apply', 'woo-check' ); ?>
+        </button>
+    </form>
+</div>
+<table class="inventory-table">
+    <thead>
+        <tr>
+            <th><?php esc_html_e( 'Libro', 'woo-check' ); ?></th>
+            <th><?php esc_html_e( 'Vendidos', 'woo-check' ); ?></th>
+            <th><?php esc_html_e( 'Stock actual', 'woo-check' ); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php
+        global $wpdb;
+
+        foreach ( $books as $book ) {
+            if ( ! $book instanceof WC_Product ) {
+                continue;
+            }
+
+            $book_id = $book->get_id();
+            $stock   = $book->get_stock_quantity();
+
+            $sales = $wpdb->get_var(
+                $wpdb->prepare(
+                    "
+                    SELECT SUM( CAST( qty_meta.meta_value AS UNSIGNED ) )
+                    FROM {$wpdb->prefix}woocommerce_order_items AS order_items
+                    INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS product_meta
+                        ON order_items.order_item_id = product_meta.order_item_id
+                    INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS qty_meta
+                        ON order_items.order_item_id = qty_meta.order_item_id
+                    INNER JOIN {$wpdb->posts} AS posts
+                        ON order_items.order_id = posts.ID
+                    WHERE product_meta.meta_key = '_product_id'
+                        AND product_meta.meta_value = %d
+                        AND qty_meta.meta_key = '_qty'
+                        AND posts.post_type = 'shop_order'
+                        AND posts.post_status IN ( 'wc-processing', 'wc-completed' )
+                        AND posts.post_date BETWEEN %s AND %s
+                    ",
+                    $book_id,
+                    $start_datetime,
+                    $end_datetime
+                )
+            );
+
+            $sales = $sales ? (int) $sales : 0;
+            ?>
+            <tr>
+                <td><?php echo esc_html( $book->get_name() ); ?></td>
+                <td><?php echo esc_html( $sales ); ?></td>
+                <td><?php echo esc_html( null !== $stock ? (string) $stock : __( 'N/A', 'woo-check' ) ); ?></td>
+            </tr>
+            <?php
+        }
+        ?>
+    </tbody>
+</table>

--- a/views/inventory.php
+++ b/views/inventory.php
@@ -9,26 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-$current_time    = current_time( 'timestamp' );
-$default_start   = wp_date( 'Y-m-d', $current_time - WEEK_IN_SECONDS );
-$default_end     = wp_date( 'Y-m-d', $current_time );
-$raw_start_date  = isset( $_GET['start_date'] ) ? sanitize_text_field( wp_unslash( $_GET['start_date'] ) ) : $default_start;
-$raw_end_date    = isset( $_GET['end_date'] ) ? sanitize_text_field( wp_unslash( $_GET['end_date'] ) ) : $default_end;
-$start_date      = $raw_start_date;
-$end_date        = $raw_end_date;
-
-// Ensure valid dates in Y-m-d format.
-if ( ! wp_checkdate( substr( $start_date, 5, 2 ), substr( $start_date, 8, 2 ), substr( $start_date, 0, 4 ), $start_date ) ) {
-    $start_date = $default_start;
-}
-
-if ( ! wp_checkdate( substr( $end_date, 5, 2 ), substr( $end_date, 8, 2 ), substr( $end_date, 0, 4 ), $end_date ) ) {
-    $end_date = $default_end;
-}
-
-$start_datetime = $start_date . ' 00:00:00';
-$end_datetime   = $end_date . ' 23:59:59';
-
 $books = wc_get_products(
     [
         'status'   => 'publish',
@@ -69,11 +49,8 @@ foreach ( $books as $book ) {
                 AND qty_meta.meta_key = '_qty'
                 AND posts.post_type = 'shop_order'
                 AND posts.post_status IN ( 'wc-processing', 'wc-completed' )
-                AND posts.post_date BETWEEN %s AND %s
             ",
-            $book_id,
-            $start_datetime,
-            $end_datetime
+            $book_id
         )
     );
 
@@ -95,21 +72,6 @@ foreach ( $books as $book ) {
 
 ?>
 <div class="inventory-container">
-    <div class="inventory-header">
-        <form method="get" class="inventory-filter-form">
-            <label>
-                <?php esc_html_e( 'Start Date:', 'woo-check' ); ?>
-            </label>
-            <input type="date" name="start_date" value="<?php echo esc_attr( $start_date ); ?>">
-            <label>
-                <?php esc_html_e( 'End Date:', 'woo-check' ); ?>
-            </label>
-            <input type="date" name="end_date" value="<?php echo esc_attr( $end_date ); ?>">
-            <button type="submit" class="button">
-                <?php esc_html_e( 'Apply', 'woo-check' ); ?>
-            </button>
-        </form>
-    </div>
     <table class="inventory-table">
         <thead>
             <tr>
@@ -179,32 +141,6 @@ foreach ( $books as $book ) {
     max-width: 900px;
     margin: 30px auto;
     font-family: system-ui, sans-serif;
-}
-
-.inventory-header {
-    text-align: left;
-    margin-bottom: 20px;
-}
-
-.inventory-filter-form {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    flex-wrap: wrap;
-    font-size: 15px;
-    color: #333;
-}
-
-.inventory-filter-form label {
-    font-weight: 600;
-    text-transform: uppercase;
-}
-
-.inventory-filter-form input[type="date"] {
-    padding: 6px 10px;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    font-size: 15px;
 }
 
 .inventory-table {


### PR DESCRIPTION
## Summary
- add toolbar switch markup and styles to toggle between packing and inventory views
- wrap the packing dashboard elements in a new container and add an inventory placeholder section
- add JavaScript to swap visibility between the packing and inventory sections without reloading the page

## Testing
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68ea6e764d988332bc5504dfe20961d3