### PR TITLE
Add HPOS-compatible inventory filtering by start date

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1075,21 +1075,43 @@ function villegas_packing_list_shortcode( $atts ) {
                 return;
             }
 
-            showPacking.addEventListener( 'click', function ( event ) {
-                event.preventDefault();
+            var activatePacking = function () {
                 packingPage.style.display = 'block';
                 inventoryPage.style.display = 'none';
                 showPacking.classList.add( 'active' );
                 showInventory.classList.remove( 'active' );
-            } );
+            };
 
-            showInventory.addEventListener( 'click', function ( event ) {
-                event.preventDefault();
+            var activateInventory = function () {
                 packingPage.style.display = 'none';
                 inventoryPage.style.display = 'block';
                 showInventory.classList.add( 'active' );
                 showPacking.classList.remove( 'active' );
+            };
+
+            showPacking.addEventListener( 'click', function ( event ) {
+                event.preventDefault();
+                activatePacking();
             } );
+
+            showInventory.addEventListener( 'click', function ( event ) {
+                event.preventDefault();
+                activateInventory();
+            } );
+
+            var shouldShowInventory = false;
+
+            try {
+                shouldShowInventory = ( new URLSearchParams( window.location.search ) ).has( 'start_date' );
+            } catch ( error ) {
+                shouldShowInventory = window.location.search.indexOf( 'start_date=' ) !== -1;
+            }
+
+            if ( shouldShowInventory ) {
+                activateInventory();
+            } else {
+                activatePacking();
+            }
         } );
     </script>
     <?php

--- a/views/inventory.php
+++ b/views/inventory.php
@@ -291,10 +291,10 @@ foreach ( $books as $book ) {
 }
 
 .bar-fill--sales {
-    background: #4e79a7;
+    background: #c0deff;
 }
 
 .bar-fill--stock {
-    background: #59a14f;
+    background: #c0deff;
 }
 </style>

--- a/views/inventory.php
+++ b/views/inventory.php
@@ -9,6 +9,26 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+$default_start = '2025-10-10';
+$raw_start     = isset( $_GET['start_date'] ) ? wp_unslash( $_GET['start_date'] ) : $default_start;
+$start_date    = ( is_string( $raw_start ) && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $raw_start ) ) ? $raw_start : $default_start;
+
+$timezone = wp_timezone();
+$utc      = new DateTimeZone( 'UTC' );
+
+try {
+    $start_datetime = new DateTimeImmutable( $start_date, $timezone );
+} catch ( Exception $e ) {
+    $start_datetime = new DateTimeImmutable( $default_start, $timezone );
+    $start_date     = $default_start;
+}
+
+$start_of_day     = $start_datetime->setTime( 0, 0, 0 );
+$start_boundary   = $start_of_day->setTimezone( $utc )->format( 'Y-m-d H:i:s' );
+$today            = new DateTimeImmutable( 'now', $timezone );
+$display_end_date = $today->format( 'Y-m-d' );
+$end_boundary     = $today->modify( '+1 day' )->setTime( 0, 0, 0 )->setTimezone( $utc )->format( 'Y-m-d H:i:s' );
+
 $books = wc_get_products(
     [
         'status'   => 'publish',
@@ -19,9 +39,9 @@ $books = wc_get_products(
     ]
 );
 
-$data       = [];
-$max_sales  = 0;
-$max_stock  = 0;
+$data      = [];
+$max_sales = 0;
+$max_stock = 0;
 
 global $wpdb;
 
@@ -37,20 +57,24 @@ foreach ( $books as $book ) {
         $wpdb->prepare(
             "
             SELECT SUM( CAST( qty_meta.meta_value AS UNSIGNED ) )
-            FROM {$wpdb->prefix}woocommerce_order_items AS order_items
+            FROM {$wpdb->prefix}wc_orders AS orders
+            INNER JOIN {$wpdb->prefix}woocommerce_order_items AS order_items
+                ON orders.id = order_items.order_id
             INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS product_meta
                 ON order_items.order_item_id = product_meta.order_item_id
             INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS qty_meta
                 ON order_items.order_item_id = qty_meta.order_item_id
-            INNER JOIN {$wpdb->posts} AS posts
-                ON order_items.order_id = posts.ID
             WHERE product_meta.meta_key = '_product_id'
                 AND product_meta.meta_value = %d
                 AND qty_meta.meta_key = '_qty'
-                AND posts.post_type = 'shop_order'
-                AND posts.post_status IN ( 'wc-processing', 'wc-completed' )
+                AND orders.status IN ( 'wc-processing', 'wc-completed' )
+                AND orders.type = 'shop_order'
+                AND orders.date_created_gmt >= %s
+                AND orders.date_created_gmt < %s
             ",
-            $book_id
+            $book_id,
+            $start_boundary,
+            $end_boundary
         )
     );
 
@@ -69,9 +93,33 @@ foreach ( $books as $book ) {
         $max_stock = max( $max_stock, $stock_value );
     }
 }
-
 ?>
 <div class="inventory-container">
+    <div class="inventory-header">
+        <form method="get" class="inventory-filter-form">
+            <label for="start_date" class="inventory-filter-label">
+                <?php esc_html_e( 'Start Date', 'woo-check' ); ?>
+            </label>
+            <input
+                type="date"
+                id="start_date"
+                name="start_date"
+                value="<?php echo esc_attr( $start_date ); ?>"
+            />
+            <button type="submit" class="inventory-filter-button button">
+                <?php esc_html_e( 'Apply', 'woo-check' ); ?>
+            </button>
+            <span class="inventory-filter-note">
+                <?php
+                printf(
+                    /* translators: %s: end date */
+                    esc_html__( 'Counting until today: %s', 'woo-check' ),
+                    esc_html( $display_end_date )
+                );
+                ?>
+            </span>
+        </form>
+    </div>
     <table class="inventory-table">
         <thead>
             <tr>
@@ -141,6 +189,34 @@ foreach ( $books as $book ) {
     max-width: 900px;
     margin: 30px auto;
     font-family: system-ui, sans-serif;
+}
+
+.inventory-header {
+    margin-bottom: 20px;
+}
+
+.inventory-filter-form {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    font-size: 14px;
+}
+
+.inventory-filter-label {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.inventory-filter-button {
+    padding: 6px 18px;
+    border-radius: 4px;
+}
+
+.inventory-filter-note {
+    font-size: 13px;
+    color: #666;
 }
 
 .inventory-table {


### PR DESCRIPTION
## Summary
- add a start date filter (defaulting to 2025-10-10) for the inventory view
- count Libro product sales via HPOS `wc_orders` records within the selected window
- expose a UI selector and note about counting through today while keeping the stock/sales bars

## Testing
- php -l views/inventory.php

------
https://chatgpt.com/codex/tasks/task_e_68ea80a53b4883328812912804520ba1