### PR TITLE
Add standalone villegas inventory shortcode

### DIFF
--- a/assets/inventory.css
+++ b/assets/inventory.css
@@ -1,0 +1,113 @@
+.inventory-container {
+    width: 90%;
+    max-width: 900px;
+    margin: 30px auto;
+    font-family: system-ui, sans-serif;
+}
+
+.inventory-header {
+    margin-bottom: 20px;
+}
+
+.inventory-filter-form {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+    font-size: 14px;
+}
+
+.inventory-filter-label {
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.inventory-filter-button {
+    padding: 6px 18px;
+    border-radius: 4px;
+}
+
+.inventory-filter-note {
+    font-size: 13px;
+    color: #666;
+}
+
+.inventory-table {
+    width: 100%;
+    border-collapse: collapse;
+    border: 1px solid #ddd;
+    font-size: 15px;
+    background: #fff;
+}
+
+.inventory-table thead {
+    background: #f6f6f6;
+    border-bottom: 2px solid #ccc;
+}
+
+.inventory-table th {
+    text-align: left;
+    padding: 12px 14px;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: #222;
+    border-bottom: 1px solid #ddd;
+    letter-spacing: 0.04em;
+}
+
+.inventory-table td {
+    padding: 12px 14px;
+    border-bottom: 1px solid #eee;
+    color: #333;
+}
+
+.inventory-table tr:hover {
+    background: #fafafa;
+}
+
+.inventory-empty {
+    text-align: center;
+    padding: 24px 16px;
+    font-style: italic;
+    color: #666;
+}
+
+.bar-cell {
+    width: 40%;
+}
+
+.bar-wrapper {
+    position: relative;
+    height: 28px;
+    border-radius: 4px;
+    background: #f0f0f0;
+    overflow: hidden;
+    display: flex;
+    align-items: center;
+    padding-left: 12px;
+}
+
+.bar-label {
+    font-size: 14px;
+    font-weight: 600;
+    color: #111;
+    z-index: 1;
+}
+
+.bar-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    border-radius: 4px;
+    transition: width 0.4s ease;
+}
+
+.bar-fill--sales {
+    background: #c0deff;
+}
+
+.bar-fill--stock {
+    background: #c0deff;
+}

--- a/functions.php
+++ b/functions.php
@@ -663,12 +663,7 @@ function villegas_packing_list_shortcode( $atts ) {
     }
 
     ?>
-    <div class="villegas-toolbar-switch">
-        <a href="#" id="show-packing" class="active"><?php esc_html_e( 'PACKING', 'woo-check' ); ?></a> |
-        <a href="#" id="show-inventory"><?php esc_html_e( 'INVENTORY', 'woo-check' ); ?></a>
-    </div>
-    <div id="packing-stats-page">
-        <div id="packing-stats">
+    <div id="packing-stats">
             <?php
             $range_display_format = function_exists( 'get_option' ) ? (string) get_option( 'date_format', 'M j, Y' ) : 'M j, Y';
 
@@ -948,7 +943,8 @@ function villegas_packing_list_shortcode( $atts ) {
 
             new Chart( chartCanvas.getContext( '2d' ), config );
         } )();
-    </script>
+        </script>
+    </div>
 
     <?php
     $pagination_markup = '';
@@ -1054,66 +1050,6 @@ function villegas_packing_list_shortcode( $atts ) {
             </tbody>
             </table>
         </div>
-    </div>
-    <div id="inventory-stats-page" style="display:none;">
-        <?php
-        $inventory_view = __DIR__ . '/views/inventory.php';
-
-        if ( file_exists( $inventory_view ) ) {
-            include $inventory_view;
-        }
-        ?>
-    </div>
-    <script>
-        document.addEventListener( 'DOMContentLoaded', function () {
-            var packingPage = document.getElementById( 'packing-stats-page' );
-            var inventoryPage = document.getElementById( 'inventory-stats-page' );
-            var showPacking = document.getElementById( 'show-packing' );
-            var showInventory = document.getElementById( 'show-inventory' );
-
-            if ( ! packingPage || ! inventoryPage || ! showPacking || ! showInventory ) {
-                return;
-            }
-
-            var activatePacking = function () {
-                packingPage.style.display = 'block';
-                inventoryPage.style.display = 'none';
-                showPacking.classList.add( 'active' );
-                showInventory.classList.remove( 'active' );
-            };
-
-            var activateInventory = function () {
-                packingPage.style.display = 'none';
-                inventoryPage.style.display = 'block';
-                showInventory.classList.add( 'active' );
-                showPacking.classList.remove( 'active' );
-            };
-
-            showPacking.addEventListener( 'click', function ( event ) {
-                event.preventDefault();
-                activatePacking();
-            } );
-
-            showInventory.addEventListener( 'click', function ( event ) {
-                event.preventDefault();
-                activateInventory();
-            } );
-
-            var shouldShowInventory = false;
-
-            try {
-                shouldShowInventory = ( new URLSearchParams( window.location.search ) ).has( 'start_date' );
-            } catch ( error ) {
-                shouldShowInventory = window.location.search.indexOf( 'start_date=' ) !== -1;
-            }
-
-            if ( shouldShowInventory ) {
-                activateInventory();
-            } else {
-                activatePacking();
-            }
-        } );
-    </script>
     <?php
 
     return trim( ob_get_clean() );

--- a/functions.php
+++ b/functions.php
@@ -325,6 +325,11 @@ function villegas_packing_list_shortcode( $atts ) {
                 border-bottom: 2px solid black;
             }
 
+            #villegas-packing-container {
+                max-width: 1200px;
+                margin: 0 auto;
+            }
+
             .villegas-packing-list {
                 border: 1px solid #ccc;
                 border-collapse: collapse;
@@ -981,74 +986,76 @@ function villegas_packing_list_shortcode( $atts ) {
     }
 
     ?>
-        <div id="villegas-packing-toolbar" class="villegas-packing-toolbar">
-            <div class="packing-region-toggle" role="group" aria-label="<?php esc_attr_e( 'Filter orders by region', 'woo-check' ); ?>">
-                <button type="button" class="packing-region-toggle__button is-active" data-region-filter="all" aria-pressed="true">
-                    <?php echo esc_html_x( 'ALL', 'Filter region option for all orders', 'woo-check' ); ?>
-                </button>
-                <button type="button" class="packing-region-toggle__button" data-region-filter="rm" aria-pressed="false">
-                    <?php echo esc_html_x( 'RECIBELO', 'Filter region option for Región Metropolitana orders', 'woo-check' ); ?>
-                </button>
-                <button type="button" class="packing-region-toggle__button" data-region-filter="non-rm" aria-pressed="false">
-                    <?php echo esc_html_x( 'SHIPIT', 'Filter region option for non Región Metropolitana orders', 'woo-check' ); ?>
-                </button>
+        <div id="villegas-packing-container">
+            <div id="villegas-packing-toolbar" class="villegas-packing-toolbar">
+                <div class="packing-region-toggle" role="group" aria-label="<?php esc_attr_e( 'Filter orders by region', 'woo-check' ); ?>">
+                    <button type="button" class="packing-region-toggle__button is-active" data-region-filter="all" aria-pressed="true">
+                        <?php echo esc_html_x( 'ALL', 'Filter region option for all orders', 'woo-check' ); ?>
+                    </button>
+                    <button type="button" class="packing-region-toggle__button" data-region-filter="rm" aria-pressed="false">
+                        <?php echo esc_html_x( 'RECIBELO', 'Filter region option for Región Metropolitana orders', 'woo-check' ); ?>
+                    </button>
+                    <button type="button" class="packing-region-toggle__button" data-region-filter="non-rm" aria-pressed="false">
+                        <?php echo esc_html_x( 'SHIPIT', 'Filter region option for non Región Metropolitana orders', 'woo-check' ); ?>
+                    </button>
+                </div>
+                <?php echo $pagination_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
             </div>
-            <?php echo $pagination_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-        </div>
-        <div id="villegas-packing-list">
-            <table class="villegas-packing-list">
-                <thead>
-                    <tr>
-                        <th class="packing-select">
-                        <span class="screen-reader-text"><?php esc_html_e( 'Select order', 'woo-check' ); ?></span>
-                    </th>
-                    <th><?php esc_html_e( 'Order ID', 'woo-check' ); ?></th>
-                    <th><?php esc_html_e( 'Items', 'woo-check' ); ?></th>
-                    <th><?php esc_html_e( 'Region', 'woo-check' ); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ( $orders as $order ) : ?>
-                    <?php if ( ! $order instanceof WC_Order ) { continue; } ?>
-                    <?php
-                    $order_id    = $order->get_id();
-                    $region_name = $order_region_cache[ $order_id ] ?? $determine_region_label( $order );
-                    $region_type = $is_metropolitana_order( $order, $region_name ) ? 'rm' : 'non-rm';
-                    ?>
-                    <tr data-region-group="<?php echo esc_attr( $region_type ); ?>">
-                        <td>
-                            <input
-                                type="checkbox"
-                                class="packing-checkbox"
-                                data-order-id="<?php echo esc_attr( $order->get_id() ); ?>"
-                                aria-label="<?php echo esc_attr( sprintf( __( 'Select order %d', 'woo-check' ), $order->get_id() ) ); ?>"
-                            />
-                        </td>
-                        <td><?php echo esc_html( $order->get_id() ); ?></td>
-                        <td>
-                            <?php
-                            $item_lines = [];
-
-                            foreach ( $order->get_items() as $item ) {
-                                $line = sprintf(
-                                    '%s - %s',
-                                    $item->get_name(),
-                                    wc_stock_amount( $item->get_quantity() )
-                                );
-
-                                $item_lines[] = esc_html( $line );
-                            }
-
-                            echo wp_kses_post( implode( '<br />', $item_lines ) );
-                            ?>
-                        </td>
-                        <td>
-                            <?php echo esc_html( $region_name ); ?>
-                        </td>
+            <div id="villegas-packing-list">
+                <table class="villegas-packing-list">
+                    <thead>
+                        <tr>
+                            <th class="packing-select">
+                            <span class="screen-reader-text"><?php esc_html_e( 'Select order', 'woo-check' ); ?></span>
+                        </th>
+                        <th><?php esc_html_e( 'Order ID', 'woo-check' ); ?></th>
+                        <th><?php esc_html_e( 'Items', 'woo-check' ); ?></th>
+                        <th><?php esc_html_e( 'Region', 'woo-check' ); ?></th>
                     </tr>
-                <?php endforeach; ?>
-            </tbody>
-            </table>
+                </thead>
+                <tbody>
+                    <?php foreach ( $orders as $order ) : ?>
+                        <?php if ( ! $order instanceof WC_Order ) { continue; } ?>
+                        <?php
+                        $order_id    = $order->get_id();
+                        $region_name = $order_region_cache[ $order_id ] ?? $determine_region_label( $order );
+                        $region_type = $is_metropolitana_order( $order, $region_name ) ? 'rm' : 'non-rm';
+                        ?>
+                        <tr data-region-group="<?php echo esc_attr( $region_type ); ?>">
+                            <td>
+                                <input
+                                    type="checkbox"
+                                    class="packing-checkbox"
+                                    data-order-id="<?php echo esc_attr( $order->get_id() ); ?>"
+                                    aria-label="<?php echo esc_attr( sprintf( __( 'Select order %d', 'woo-check' ), $order->get_id() ) ); ?>"
+                                />
+                            </td>
+                            <td><?php echo esc_html( $order->get_id() ); ?></td>
+                            <td>
+                                <?php
+                                $item_lines = [];
+
+                                foreach ( $order->get_items() as $item ) {
+                                    $line = sprintf(
+                                        '%s - %s',
+                                        $item->get_name(),
+                                        wc_stock_amount( $item->get_quantity() )
+                                    );
+
+                                    $item_lines[] = esc_html( $line );
+                                }
+
+                                echo wp_kses_post( implode( '<br />', $item_lines ) );
+                                ?>
+                            </td>
+                            <td>
+                                <?php echo esc_html( $region_name ); ?>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+                </table>
+            </div>
         </div>
     <?php
 

--- a/includes/shortcodes/inventory.php
+++ b/includes/shortcodes/inventory.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Inventory shortcode for Libro category products.
+ *
+ * @package Woo_Check
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+add_shortcode( 'villegas-inventario', 'villegas_render_inventory_page' );
+
+/**
+ * Render the inventory page with sales and stock information.
+ *
+ * @param array $atts Shortcode attributes.
+ * @return string
+ */
+function villegas_render_inventory_page( $atts = [] ) {
+    if ( ! function_exists( 'wc_get_products' ) ) {
+        return '';
+    }
+
+    if ( ! current_user_can( 'manage_options' ) ) {
+        return '<p>' . esc_html__( 'Información Confidencial', 'woo-check' ) . '</p>';
+    }
+
+    $default_start = '2025-10-10';
+    $raw_start     = isset( $_GET['start_date'] ) ? wp_unslash( $_GET['start_date'] ) : $default_start; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+    $start_date    = ( is_string( $raw_start ) && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $raw_start ) ) ? $raw_start : $default_start;
+
+    $timezone = function_exists( 'wp_timezone' ) ? wp_timezone() : null;
+
+    if ( ! $timezone instanceof DateTimeZone ) {
+        try {
+            $timezone = new DateTimeZone( date_default_timezone_get() );
+        } catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+        }
+
+        if ( ! $timezone instanceof DateTimeZone ) {
+            $timezone = new DateTimeZone( 'UTC' );
+        }
+    }
+
+    try {
+        $today = new DateTimeImmutable( 'now', $timezone );
+    } catch ( Exception $e ) {
+        $today = new DateTimeImmutable( 'now' );
+    }
+
+    $display_end_date = $today->format( 'Y-m-d' );
+    $end_date         = $display_end_date;
+
+    $products = wc_get_products(
+        [
+            'status'   => 'publish',
+            'category' => [ 'libro' ],
+            'limit'    => -1,
+            'orderby'  => 'title',
+            'order'    => 'ASC',
+        ]
+    );
+
+    $sales_counts = class_exists( 'Woo_Check_Inventory' )
+        ? Woo_Check_Inventory::get_sales_counts( $start_date, $end_date )
+        : [];
+
+    $rows      = [];
+    $max_sales = 0;
+    $max_stock = 0;
+
+    foreach ( $products as $product ) {
+        if ( ! $product instanceof WC_Product ) {
+            continue;
+        }
+
+        $product_id = $product->get_id();
+        $stock_raw  = $product->get_stock_quantity();
+        $stock      = null !== $stock_raw ? (int) $stock_raw : null;
+
+        $sales = isset( $sales_counts[ $product_id ] ) ? (int) $sales_counts[ $product_id ] : 0;
+
+        $rows[] = [
+            'name'  => $product->get_name(),
+            'sales' => $sales,
+            'stock' => $stock,
+        ];
+
+        $max_sales = max( $max_sales, $sales );
+
+        if ( null !== $stock ) {
+            $max_stock = max( $max_stock, $stock );
+        }
+    }
+
+    $villegas_inventory_context = [
+        'start_date'        => $start_date,
+        'display_end_date'  => $display_end_date,
+        'rows'              => $rows,
+        'max_sales'         => $max_sales,
+        'max_stock'         => $max_stock,
+    ];
+
+    $plugin_root      = dirname( dirname( __DIR__ ) );
+    $inventory_view   = trailingslashit( $plugin_root ) . 'views/inventory.php';
+
+    ob_start();
+    ?>
+    <div id="inventory-stats-page">
+        <?php
+        if ( file_exists( $inventory_view ) ) {
+            include $inventory_view;
+        } else {
+            echo '<p>' . esc_html__( 'Inventory view template not found.', 'woo-check' ) . '</p>';
+        }
+        ?>
+    </div>
+    <?php
+    return trim( ob_get_clean() );
+}
+
+/**
+ * Enqueue shared inventory styles.
+ */
+function villegas_inventory_enqueue_assets() {
+    if ( is_admin() ) {
+        return;
+    }
+
+    $plugin_root = dirname( dirname( __DIR__ ) );
+    $plugin_file = trailingslashit( $plugin_root ) . 'woo-check.php';
+    $style_path  = trailingslashit( $plugin_root ) . 'assets/inventory.css';
+    $style_url   = plugins_url( 'assets/inventory.css', $plugin_file );
+    $version     = file_exists( $style_path ) ? (string) filemtime( $style_path ) : null;
+
+    wp_enqueue_style( 'villegas-inventory', $style_url, [], $version );
+}
+add_action( 'wp_enqueue_scripts', 'villegas_inventory_enqueue_assets' );

--- a/views/inventory.php
+++ b/views/inventory.php
@@ -9,57 +9,17 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-$default_start = '2025-10-10';
-$raw_start     = isset( $_GET['start_date'] ) ? wp_unslash( $_GET['start_date'] ) : $default_start;
-$start_date    = ( is_string( $raw_start ) && preg_match( '/^\d{4}-\d{2}-\d{2}$/', $raw_start ) ) ? $raw_start : $default_start;
-
-$timezone = wp_timezone();
-
-$today            = new DateTimeImmutable( 'now', $timezone );
-$display_end_date = $today->format( 'Y-m-d' );
-$end_date         = $display_end_date;
-
-$books = wc_get_products(
-    [
-        'status'   => 'publish',
-        'category' => [ 'libro' ],
-        'limit'    => -1,
-        'orderby'  => 'title',
-        'order'    => 'ASC',
-    ]
-);
-
-$data      = [];
-$max_sales = 0;
-$max_stock = 0;
-
-$sales_counts = class_exists( 'Woo_Check_Inventory' )
-    ? Woo_Check_Inventory::get_sales_counts( $start_date, $end_date )
+$villegas_inventory_context = isset( $villegas_inventory_context ) && is_array( $villegas_inventory_context )
+    ? $villegas_inventory_context
     : [];
 
-foreach ( $books as $book ) {
-    if ( ! $book instanceof WC_Product ) {
-        continue;
-    }
-
-    $book_id = $book->get_id();
-    $stock   = $book->get_stock_quantity();
-
-    $sales_value = isset( $sales_counts[ $book_id ] ) ? (int) $sales_counts[ $book_id ] : 0;
-    $stock_value = null !== $stock ? (int) $stock : null;
-
-    $data[] = [
-        'name'  => $book->get_name(),
-        'sales' => $sales_value,
-        'stock' => $stock_value,
-    ];
-
-    $max_sales = max( $max_sales, $sales_value );
-
-    if ( null !== $stock_value ) {
-        $max_stock = max( $max_stock, $stock_value );
-    }
-}
+$start_date       = isset( $villegas_inventory_context['start_date'] ) ? (string) $villegas_inventory_context['start_date'] : '';
+$display_end_date = isset( $villegas_inventory_context['display_end_date'] ) ? (string) $villegas_inventory_context['display_end_date'] : '';
+$rows             = isset( $villegas_inventory_context['rows'] ) && is_array( $villegas_inventory_context['rows'] )
+    ? $villegas_inventory_context['rows']
+    : [];
+$max_sales        = isset( $villegas_inventory_context['max_sales'] ) ? (int) $villegas_inventory_context['max_sales'] : 0;
+$max_stock        = isset( $villegas_inventory_context['max_stock'] ) ? (int) $villegas_inventory_context['max_stock'] : 0;
 ?>
 <div class="inventory-container">
     <div class="inventory-header">
@@ -76,6 +36,7 @@ foreach ( $books as $book ) {
             <button type="submit" class="inventory-filter-button button">
                 <?php esc_html_e( 'Apply', 'woo-check' ); ?>
             </button>
+            <?php if ( '' !== $display_end_date ) : ?>
             <span class="inventory-filter-note">
                 <?php
                 printf(
@@ -85,6 +46,7 @@ foreach ( $books as $book ) {
                 );
                 ?>
             </span>
+            <?php endif; ?>
         </form>
     </div>
     <table class="inventory-table">
@@ -96,32 +58,36 @@ foreach ( $books as $book ) {
             </tr>
         </thead>
         <tbody>
-        <?php if ( empty( $data ) ) : ?>
+        <?php if ( empty( $rows ) ) : ?>
             <tr>
                 <td colspan="3" class="inventory-empty">
                     <?php esc_html_e( 'No books found in the Libro category.', 'woo-check' ); ?>
                 </td>
             </tr>
         <?php else : ?>
-            <?php foreach ( $data as $row ) :
+            <?php foreach ( $rows as $row ) :
+                $book_name = isset( $row['name'] ) ? (string) $row['name'] : '';
+                $sales     = isset( $row['sales'] ) ? (int) $row['sales'] : 0;
+                $stock     = array_key_exists( 'stock', $row ) ? $row['stock'] : null;
+
                 $sales_percent = 0;
                 $stock_percent = 0;
 
                 if ( $max_sales > 0 ) {
-                    $sales_percent = min( 100, ( $row['sales'] / $max_sales ) * 100 );
+                    $sales_percent = min( 100, ( $sales / $max_sales ) * 100 );
                     $sales_percent = round( $sales_percent, 2 );
                 }
 
-                if ( $max_stock > 0 && null !== $row['stock'] ) {
-                    $stock_percent = min( 100, ( $row['stock'] / $max_stock ) * 100 );
+                if ( $max_stock > 0 && null !== $stock ) {
+                    $stock_percent = min( 100, ( $stock / $max_stock ) * 100 );
                     $stock_percent = round( $stock_percent, 2 );
                 }
             ?>
             <tr>
-                <td class="book-name"><?php echo esc_html( $row['name'] ); ?></td>
+                <td class="book-name"><?php echo esc_html( $book_name ); ?></td>
                 <td class="bar-cell">
                     <div class="bar-wrapper">
-                        <span class="bar-label"><?php echo esc_html( number_format_i18n( $row['sales'] ) ); ?></span>
+                        <span class="bar-label"><?php echo esc_html( number_format_i18n( $sales ) ); ?></span>
                         <div
                             class="bar-fill bar-fill--sales"
                             style="width: <?php echo esc_attr( $sales_percent ); ?>%;"
@@ -132,9 +98,9 @@ foreach ( $books as $book ) {
                 <td class="bar-cell">
                     <div class="bar-wrapper">
                         <span class="bar-label">
-                            <?php echo null !== $row['stock'] ? esc_html( number_format_i18n( $row['stock'] ) ) : esc_html__( 'N/A', 'woo-check' ); ?>
+                            <?php echo null !== $stock ? esc_html( number_format_i18n( (int) $stock ) ) : esc_html__( 'N/A', 'woo-check' ); ?>
                         </span>
-                        <?php if ( null !== $row['stock'] ) : ?>
+                        <?php if ( null !== $stock ) : ?>
                         <div
                             class="bar-fill bar-fill--stock"
                             style="width: <?php echo esc_attr( $stock_percent ); ?>%;"
@@ -149,119 +115,3 @@ foreach ( $books as $book ) {
         </tbody>
     </table>
 </div>
-
-<style>
-.inventory-container {
-    width: 90%;
-    max-width: 900px;
-    margin: 30px auto;
-    font-family: system-ui, sans-serif;
-}
-
-.inventory-header {
-    margin-bottom: 20px;
-}
-
-.inventory-filter-form {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 10px;
-    font-size: 14px;
-}
-
-.inventory-filter-label {
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-}
-
-.inventory-filter-button {
-    padding: 6px 18px;
-    border-radius: 4px;
-}
-
-.inventory-filter-note {
-    font-size: 13px;
-    color: #666;
-}
-
-.inventory-table {
-    width: 100%;
-    border-collapse: collapse;
-    border: 1px solid #ddd;
-    font-size: 15px;
-    background: #fff;
-}
-
-.inventory-table thead {
-    background: #f6f6f6;
-    border-bottom: 2px solid #ccc;
-}
-
-.inventory-table th {
-    text-align: left;
-    padding: 12px 14px;
-    font-weight: 600;
-    text-transform: uppercase;
-    color: #222;
-    border-bottom: 1px solid #ddd;
-    letter-spacing: 0.04em;
-}
-
-.inventory-table td {
-    padding: 12px 14px;
-    border-bottom: 1px solid #eee;
-    color: #333;
-}
-
-.inventory-table tr:hover {
-    background: #fafafa;
-}
-
-.inventory-empty {
-    text-align: center;
-    padding: 24px 16px;
-    font-style: italic;
-    color: #666;
-}
-
-.bar-cell {
-    width: 40%;
-}
-
-.bar-wrapper {
-    position: relative;
-    height: 28px;
-    border-radius: 4px;
-    background: #f0f0f0;
-    overflow: hidden;
-    display: flex;
-    align-items: center;
-    padding-left: 12px;
-}
-
-.bar-label {
-    font-size: 14px;
-    font-weight: 600;
-    color: #111;
-    z-index: 1;
-}
-
-.bar-fill {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    border-radius: 4px;
-    transition: width 0.4s ease;
-}
-
-.bar-fill--sales {
-    background: #c0deff;
-}
-
-.bar-fill--stock {
-    background: #c0deff;
-}
-</style>

--- a/woo-check.php
+++ b/woo-check.php
@@ -17,6 +17,7 @@ require_once plugin_dir_path( __FILE__ ) . 'emails/first-quiz-email.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/polis-average-quiz-result.php';
 // Include the plugin's functions.php file
 require_once plugin_dir_path(__FILE__) . 'functions.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/shortcodes/inventory.php';
 // Load WooCheck logistics dependencies
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-check-admin.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-wc-check-recibelo-communes.php';


### PR DESCRIPTION
## Summary
- add a new [villegas-inventario] shortcode that renders Libro inventory data with shared styles
- refactor the inventory view for reuse and remove the inventory tab from the packing list shortcode
- enqueue a dedicated stylesheet so both shortcodes share the same presentation

## Testing
- php -l includes/shortcodes/inventory.php
- php -l views/inventory.php
- php -l functions.php

------
https://chatgpt.com/codex/tasks/task_e_68eac1c266608332881e5f82aca1c01a