### PR TITLE
Add modal login overlay for confidential access

### DIFF
--- a/assets/js/woo-check-login-modal.js
+++ b/assets/js/woo-check-login-modal.js
@@ -1,0 +1,175 @@
+(function () {
+    'use strict';
+
+    const bodyClass = 'woo-check-login-modal-open';
+
+    const focusableSelectors = [
+        'a[href]',
+        'button:not([disabled])',
+        'textarea:not([disabled])',
+        'input:not([type="hidden"]):not([disabled])',
+        'select:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])'
+    ];
+
+    const toggleScroll = (shouldLock) => {
+        document.body.classList.toggle(bodyClass, shouldLock);
+    };
+
+    const trapFocus = (modal, event) => {
+        if (event.key !== 'Tab') {
+            return;
+        }
+
+        const focusable = modal.querySelectorAll(focusableSelectors.join(','));
+        if (!focusable.length) {
+            return;
+        }
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement;
+
+        if (event.shiftKey && active === first) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && active === last) {
+            event.preventDefault();
+            first.focus();
+        }
+    };
+
+    const focusFirstField = (modal) => {
+        const preferredSelectors = [
+            'input[type="text"]',
+            'input[type="email"]',
+            'input[type="password"]',
+            'input',
+            'button',
+            '[tabindex]'
+        ];
+
+        for (const selector of preferredSelectors) {
+            const element = modal.querySelector(selector);
+            if (element) {
+                element.focus();
+                return;
+            }
+        }
+    };
+
+    const getModalByTrigger = (trigger) => {
+        const targetId = trigger.getAttribute('data-woo-check-modal-target');
+        if (!targetId) {
+            return null;
+        }
+        return document.getElementById(targetId) || null;
+    };
+
+    const closeModal = (modal, trigger) => {
+        if (!modal) {
+            return;
+        }
+
+        const originTrigger = trigger || modal.__wooCheckTrigger || null;
+
+        modal.classList.remove('is-visible');
+        modal.setAttribute('aria-hidden', 'true');
+        modal.removeAttribute('data-woo-check-open');
+        modal.removeEventListener('keydown', modal.__wooCheckFocusTrap);
+        delete modal.__wooCheckFocusTrap;
+
+        const activeDismissButton = modal.querySelector('[data-woo-check-modal-dismiss]');
+        if (activeDismissButton) {
+            activeDismissButton.blur();
+        }
+
+        toggleScroll(false);
+
+        if (originTrigger) {
+            originTrigger.focus();
+        }
+
+        modal.__wooCheckTrigger = null;
+    };
+
+    const openModal = (modal, trigger) => {
+        if (!modal) {
+            return;
+        }
+
+        modal.classList.add('is-visible');
+        modal.setAttribute('aria-hidden', 'false');
+        modal.setAttribute('data-woo-check-open', 'true');
+
+        const focusTrapHandler = (event) => trapFocus(modal, event);
+        modal.__wooCheckFocusTrap = focusTrapHandler;
+        modal.addEventListener('keydown', focusTrapHandler);
+
+        focusFirstField(modal);
+        toggleScroll(true);
+
+        modal.__wooCheckTrigger = trigger || null;
+    };
+
+    const handleTriggerClick = (event) => {
+        const trigger = event.currentTarget;
+        const modal = getModalByTrigger(trigger);
+
+        if (!modal) {
+            return;
+        }
+
+        event.preventDefault();
+        openModal(modal, trigger);
+    };
+
+    const handleModalClick = (event) => {
+        const modal = event.currentTarget;
+        const dismissTarget = event.target.closest('[data-woo-check-modal-dismiss]');
+
+        if (dismissTarget) {
+            event.preventDefault();
+            closeModal(modal, modal.__wooCheckTrigger);
+        }
+    };
+
+    const handleEscape = (event) => {
+        if (event.key !== 'Escape') {
+            return;
+        }
+
+        const openModalElement = document.querySelector('.woo-check-login-modal[data-woo-check-open="true"]');
+        if (!openModalElement) {
+            return;
+        }
+
+        event.preventDefault();
+        closeModal(openModalElement, openModalElement.__wooCheckTrigger);
+    };
+
+    const init = () => {
+        const triggers = document.querySelectorAll('[data-woo-check-modal-target]');
+        if (!triggers.length) {
+            return;
+        }
+
+        triggers.forEach((trigger) => {
+            const modal = getModalByTrigger(trigger);
+            if (!modal) {
+                return;
+            }
+
+            trigger.addEventListener('click', handleTriggerClick);
+            modal.addEventListener('click', handleModalClick);
+        });
+
+        document.addEventListener('keydown', handleEscape);
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/general.css
+++ b/general.css
@@ -45,3 +45,153 @@ html#container-reset {
 #container-reset > body {
     background: none !important;
 }
+
+.woo-check-login-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 100000;
+}
+
+.woo-check-login-modal.is-visible {
+    display: flex;
+}
+
+body.woo-check-login-modal-open {
+    overflow: hidden;
+}
+
+.woo-check-login-modal__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.65);
+}
+
+.woo-check-login-modal__content {
+    position: relative;
+    background: #ffffff;
+    color: #111827;
+    border-radius: 12px;
+    box-shadow: 0 18px 48px rgba(0, 0, 0, 0.35);
+    padding: 2rem;
+    width: min(90%, 420px);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.woo-check-login-modal__title {
+    margin: 0;
+    font-size: 1.5rem;
+    text-align: center;
+    color: inherit;
+}
+
+.woo-check-login-modal__close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: transparent;
+    border: none;
+    color: #111827;
+    font-size: 1.75rem;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.woo-check-login-modal form,
+.woo-check-login-modal .login-form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.woo-check-login-modal label,
+.woo-check-login-modal .login-form label {
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: inherit;
+}
+
+.woo-check-login-modal input[type="text"],
+.woo-check-login-modal input[type="password"],
+.woo-check-login-modal input[type="email"] {
+    width: 100%;
+    padding: 0.65rem 0.85rem;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-size: 1rem;
+    background: #ffffff;
+    color: #111827;
+}
+
+.woo-check-login-modal input[type="text"]:focus,
+.woo-check-login-modal input[type="password"]:focus,
+.woo-check-login-modal input[type="email"]:focus {
+    outline: 2px solid #111827;
+    outline-offset: 2px;
+    border-color: #111827;
+}
+
+.woo-check-login-modal .login-remember,
+.woo-check-login-modal .woo-check-login-fallback__actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    font-size: 0.9rem;
+}
+
+.woo-check-login-modal .login-remember label,
+.woo-check-login-modal .woo-check-login-fallback__remember {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+}
+
+.woo-check-login-modal .login-submit input[type="submit"],
+.woo-check-login-modal .woo-check-login-fallback__submit {
+    margin-left: auto;
+    padding: 0.65rem 1.75rem;
+    border-radius: 999px;
+    border: none;
+    background: #000000;
+    color: #ffffff;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.woo-check-login-modal .login-submit input[type="submit"]:hover,
+.woo-check-login-modal .woo-check-login-fallback__submit:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+}
+
+.woo-check-login-modal p {
+    margin: 0;
+}
+
+.woo-check-confidential-login {
+    text-decoration: none;
+}
+
+@media (max-width: 480px) {
+    .woo-check-login-modal__content {
+        padding: 1.5rem;
+    }
+
+    .woo-check-login-modal .login-remember,
+    .woo-check-login-modal .woo-check-login-fallback__actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .woo-check-login-modal .login-submit input[type="submit"],
+    .woo-check-login-modal .woo-check-login-fallback__submit {
+        width: 100%;
+    }
+}

--- a/woo-check.php
+++ b/woo-check.php
@@ -1031,6 +1031,19 @@ function woo_check_enqueue_assets() {
         '1.0'
     );
 
+    if ( ! is_user_logged_in() ) {
+        $login_modal_script_path = plugin_dir_path(__FILE__) . 'assets/js/woo-check-login-modal.js';
+        $login_modal_script_ver  = file_exists( $login_modal_script_path ) ? filemtime( $login_modal_script_path ) : '1.0';
+
+        wp_enqueue_script(
+            'woo-check-login-modal',
+            plugin_dir_url(__FILE__) . 'assets/js/woo-check-login-modal.js',
+            array(),
+            $login_modal_script_ver,
+            true
+        );
+    }
+
     if ( function_exists( 'is_account_page' ) && is_account_page() ) {
         wp_enqueue_style(
             'woo-check-view-order',


### PR DESCRIPTION
## Summary
- replace the confidential access login link with a modal trigger and embed the WordPress login form inside the overlay so users return to the current page after signing in
- style the floating login modal and button for accessibility and responsive layouts
- enqueue a dedicated script to manage modal interactions and focus handling when the user is logged out

## Testing
- php -l functions.php
- php -l woo-check.php

------
https://chatgpt.com/codex/tasks/task_e_68eae95506848332b8b76bd93b6781e2