### PR TITLE
Hide login modal until triggered

### DIFF
--- a/assets/js/woo-check-login-modal.js
+++ b/assets/js/woo-check-login-modal.js
@@ -75,6 +75,7 @@
 
         modal.classList.remove('is-visible');
         modal.setAttribute('aria-hidden', 'true');
+        modal.setAttribute('hidden', 'hidden');
         modal.removeAttribute('data-woo-check-open');
         modal.removeEventListener('keydown', modal.__wooCheckFocusTrap);
         delete modal.__wooCheckFocusTrap;
@@ -98,6 +99,7 @@
             return;
         }
 
+        modal.removeAttribute('hidden');
         modal.classList.add('is-visible');
         modal.setAttribute('aria-hidden', 'false');
         modal.setAttribute('data-woo-check-open', 'true');

--- a/functions.php
+++ b/functions.php
@@ -91,7 +91,7 @@ if ( ! function_exists( 'woo_check_render_confidential_message' ) ) {
         }
 
         $modal_markup = sprintf(
-            '<div class="woo-check-login-modal" id="%1$s" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="%2$s">'
+            '<div class="woo-check-login-modal" id="%1$s" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="%2$s" hidden>'
             . '<div class="woo-check-login-modal__backdrop" data-woo-check-modal-dismiss></div>'
             . '<div class="woo-check-login-modal__content" role="document">'
             . '<button type="button" class="woo-check-login-modal__close" aria-label="%5$s" data-woo-check-modal-dismiss>&times;</button>'


### PR DESCRIPTION
## Summary
- keep the confidential login form hidden by default by marking the modal as hidden
- toggle the hidden attribute when the login modal opens or closes so the form only appears after clicking the button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68eaf3ad89308332b86654965dafd594